### PR TITLE
When a behavior is removed or added, issue modified event on FTI

### DIFF
--- a/plone/app/dexterity/browser/behaviors.py
+++ b/plone/app/dexterity/browser/behaviors.py
@@ -3,6 +3,7 @@ from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import adapts, getUtilitiesFor
 from zope import schema
 from zope.i18nmessageid import MessageFactory
+from zope.lifecycleevent import modified
 
 from z3c.form import field, form
 from z3c.form.browser.checkbox import SingleCheckBoxFieldWidget
@@ -12,8 +13,12 @@ from plone.app.dexterity.interfaces import ITypeSchemaContext
 from plone.app.dexterity.browser.layout import TypeFormLayout
 from plone.app.dexterity import MessageFactory as _
 
-
 PMF = MessageFactory('plone')
+
+
+def behaviorConfigurationModified(object, event):
+    modified(object.fti, "behaviors")
+
 
 class BehaviorConfigurationAdapter(object):
     adapts(ITypeSchemaContext)

--- a/plone/app/dexterity/events.zcml
+++ b/plone/app/dexterity/events.zcml
@@ -9,4 +9,10 @@
         handler=".serialize.serializeSchemaContext"
         />
 
+    <subscriber
+        for=".browser.behaviors.BehaviorConfigurationAdapter
+             zope.lifecycleevent.IObjectModifiedEvent"
+        handler=".browser.behaviors.behaviorConfigurationModified"
+        />
+
 </configure>


### PR DESCRIPTION
Previously, the modified event would not be signaled for the FTI, which means that the schema cache invalidation would not occur.
