### PR TITLE
DexterityFTIModificationDescription needed on modified event

### DIFF
--- a/plone/app/dexterity/browser/behaviors.py
+++ b/plone/app/dexterity/browser/behaviors.py
@@ -13,12 +13,14 @@ from plone.app.dexterity.interfaces import ITypeSchemaContext
 from plone.app.dexterity.browser.layout import TypeFormLayout
 from plone.app.dexterity import MessageFactory as _
 
+from plone.dexterity.fti import DexterityFTIModificationDescription
+
 PMF = MessageFactory('plone')
 
 
 def behaviorConfigurationModified(object, event):
-    modified(object.fti, "behaviors")
-
+    description = DexterityFTIModificationDescription("behaviors", "")
+    modified(object.fti, description)
 
 class BehaviorConfigurationAdapter(object):
     adapts(ITypeSchemaContext)


### PR DESCRIPTION
Fixes error on adding behaviors to content types dynamically. This fix is correct a small mistake in an earlier fix for exactly the same problem. 
