### PR TITLE
Correctly encode and decode DC field metadata strings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -27,6 +27,10 @@ Changelog for plone.app.dexterity
 2.0 (2012-08-30)
 ----------------
 
+- DC metadata fields are now correctly encoded and decoded (from byte
+  strings to unicode and vice versa). Currently, UTF-8 is assumed.
+  [malthe]
+
 - Use lxml instead of elementtree.
   [davisagli]
 

--- a/plone/app/dexterity/behaviors/tests/test_metadata.py
+++ b/plone/app/dexterity/behaviors/tests/test_metadata.py
@@ -59,3 +59,47 @@ class TestCategorization(unittest.TestCase):
         b = self._makeOne()
         b.context.subject = (u'føø',)
         self.assertEqual((u'føø',), b.subjects)
+
+
+class TestDCFieldProperty(unittest.TestCase):
+
+    def _makeOne(self):
+        class Dummy(object):
+            def addCreator(self, creator=None):
+                self.creators = (creator or 'dummy_user', )
+
+            def setRights(self, rights):
+                self.rights = rights
+
+            def Rights(self):
+                return self.rights
+
+            def setCreators(self, creators):
+                self.creators = creators
+
+            def listCreators(self):
+                return self.creators
+
+        dummy = Dummy()
+        from plone.app.dexterity.behaviors.metadata import DublinCore
+        return DublinCore(dummy)
+
+    def test_sequence_text_setter(self):
+        b = self._makeOne()
+        b.creators = (u'føø',)
+        self.assertEqual(('føø',), b.context.creators)
+
+    def test_sequence_text_getter(self):
+        b = self._makeOne()
+        b.context.creators = ('føø',)
+        self.assertEqual((u'føø',), b.creators)
+
+    def test_text_setter(self):
+        b = self._makeOne()
+        b.rights = u'føø'
+        self.assertEqual('føø', b.context.rights)
+
+    def test_text_getter(self):
+        b = self._makeOne()
+        b.context.rights = 'føø'
+        self.assertEqual(u'føø', b.rights)


### PR DESCRIPTION
Previously, the `DCFieldProperty` would only convert between `DateTime` (the Zope module) and `datetime` (Python's built-in module).

With this changeset, Zope 2 string-based fields are now correctly converted into unicode, which is required by the `IText` interface from `zope.schema`.
