### PR TITLE
additional_schemata changed to additionalSchemata

### DIFF
--- a/docs/advanced/custom-add-and-edit-forms.rst
+++ b/docs/advanced/custom-add-and-edit-forms.rst
@@ -67,7 +67,7 @@ For example, we could:
 - Override the ``schema`` property to tell `plone.autoform`_ to use a
   different schema interface (with different form hints) than the
   content type schema.
-- Override the ``additional_schemata`` property to tell `plone.autoform`_
+- Override the ``additionalSchemata`` property to tell `plone.autoform`_
   to use different supplemental schema interfaces. 
   The default is to use all behavior interfaces that provide the
   ``IFormFieldProvider`` marker from `plone.directives.form`_.


### PR DESCRIPTION
additional_schemata property changed to additionalSchemata in plone.autoform:
https://github.com/plone/plone.autoform/blob/e215744bce9d776dcdd77e340dc6a85554e0b511/CHANGES.rst#10b2---2009-07-12
