### PR TITLE
Note about brown bag release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Changelog
 2.0.12 (2014-09-07)
 -------------------
 
+**Brown bag release, please do not pin this version, use either 2.0.11, 2.0.13 or any later version.**
+
 - Don't throw an error if allowed_content_types is none or missing.
   Fix https://github.com/plone/plone.app.contenttypes/issues/91
   [pbauer]


### PR DESCRIPTION
@staeff found out that plone.app.dexterity 2.0.12 zip file on PyPi is completely broken.

Make sure that everyone is aware of it.

Fixes: https://github.com/plone/plone.app.dexterity/issues/155