### PR TITLE
Fixed an adapter path at custom add forms documentation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Remove duplicate plone.app.z3cform pin in setup.py. This fixes https://github.com/plone/plone.app.dexterity/issues/167.
   [timo]
 
+- Fixed an adapter path at custom add forms documentation.
+  [brunobbbs]
+
 
 2.1.6 (2015-06-05)
 ------------------

--- a/docs/advanced/custom-add-and-edit-forms.rst
+++ b/docs/advanced/custom-add-and-edit-forms.rst
@@ -167,7 +167,7 @@ and be registered in ZCML like this:
     <adapter
         for="Products.CMFCore.interfaces.IFolderish
              zope.publisher.interfaces.browser.IDefaultBrowserLayer
-             ..interfaces.IDexterityFTI"
+             plone.dexterity.interfaces.IDexterityFTI"
         provides="zope.publisher.interfaces.browser.IBrowserPage"
         factory=".fs_page.AddForm"
         name="example.fspage"


### PR DESCRIPTION
The documentation in this link (http://docs.plone.org/external/plone.app.dexterity/docs/advanced/custom-add-and-edit-forms.html#custom-add-forms) has been updated like in (http://docs.plone.org/develop/plone/content/dexterity.html#custom-add-form-view)

instead: ..interfaces.IDexterityFTI
use full path: plone.dexterity.interfaces.IDexterityFTI 