### PR TITLE
No need for unittest2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove unittest2 dependency.
+  [gforcada]
 
 
 2.1.11 (2015-09-11)

--- a/docs/grok/testing/integration-tests.rst
+++ b/docs/grok/testing/integration-tests.rst
@@ -95,7 +95,7 @@ that uses our layer. We’ll add one to ``test_program.py`` first.
 (In the code snippet below, the unit test we created previously has been
 removed to conserve space.)::
 
-    import unittest2 as unittest
+    import unittest
 
     from zope.component import createObject
     from zope.component import queryUtility
@@ -227,7 +227,7 @@ only.
 The other tests are similar. We have ``tests/test_session.py`` to test
 the ``Session`` type::
 
-    import unittest2 as unittest
+    import unittest
 
     from zope.component import createObject
     from zope.component import queryUtility
@@ -316,7 +316,7 @@ We also add a test for the ``possible_tracks()`` vocabulary method,
 as well as tests for the installation of the ``track`` index and metadata
 column and the custom workflow::
 
-    import unittest2 as unittest
+    import unittest
 
     from zope.component import createObject
     from zope.component import queryUtility

--- a/docs/testing/integration-tests.rst
+++ b/docs/testing/integration-tests.rst
@@ -95,7 +95,7 @@ that uses our layer. We’ll add one to ``test_program.py`` first.
 (In the code snippet below, the unit test we created previously has been
 removed to conserve space.)::
 
-    import unittest2 as unittest
+    import unittest
 
     from zope.component import createObject
     from zope.component import queryUtility

--- a/plone/app/dexterity/tests/test_constrains.py
+++ b/plone/app/dexterity/tests/test_constrains.py
@@ -13,7 +13,7 @@ from plone.app.testing import setRoles
 from plone.dexterity.fti import DexterityFTI
 from plone.testing.z2 import Browser
 from zope.interface.exceptions import Invalid
-import unittest2 as unittest
+import unittest
 
 
 def add_folder_type(portal):

--- a/plone/app/dexterity/tests/test_export.py
+++ b/plone/app/dexterity/tests/test_export.py
@@ -6,7 +6,7 @@ from xml.dom.minidom import parseString
 from xml.parsers.expat import ExpatError
 from zope.component import getMultiAdapter
 import StringIO
-import unittest2 as unittest
+import unittest
 import zipfile
 
 

--- a/plone/app/dexterity/tests/test_import.py
+++ b/plone/app/dexterity/tests/test_import.py
@@ -8,7 +8,7 @@ from plone.app.dexterity.browser.import_types import ZipFileImportContext
 from plone.app.dexterity.testing import DEXTERITY_INTEGRATION_TESTING
 import os.path
 import plone.namedfile
-import unittest2 as unittest
+import unittest
 import zope.interface
 
 

--- a/plone/app/dexterity/tests/test_nextprevious.py
+++ b/plone/app/dexterity/tests/test_nextprevious.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 from plone.app.testing import setRoles, login, logout, TEST_USER_ID
 from plone.app.dexterity.testing import DEXTERITY_INTEGRATION_TESTING
 

--- a/plone/app/dexterity/tests/test_permissions.py
+++ b/plone/app/dexterity/tests/test_permissions.py
@@ -19,12 +19,7 @@ from zope.component.globalregistry import base
 from zope.globalrequest import setRequest
 from zope.interface import Interface
 import json
-
-try:
-    import unittest2 as unittest
-except ImportError:  # pragma: nocover
-    import unittest  # pragma: nocover
-    assert unittest  # pragma: nocover
+import unittest
 
 
 def add_mock_fti(portal):

--- a/plone/app/dexterity/tests/test_upgrades.py
+++ b/plone/app/dexterity/tests/test_upgrades.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.app.dexterity.testing import DEXTERITY_INTEGRATION_TESTING
-import unittest2 as unittest
+import unittest
 
 
 class TestUpgrades(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(name='plone.app.dexterity',
           'test': [
               'plone.app.robotframework',
               'plone.app.testing',
-              'unittest2'
           ],
           'grok': [
               'five.grok',


### PR DESCRIPTION
Since python 2.7 unittest2 was already merged with unittest.