### PR TITLE
Remove bobobase_modification_time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.1.15 (unreleased)
 -------------------
 
+- No longer rely on deprecated ``bobobase_modification_time`` from
+  ``Persistence.Persistent``.
+  [thet]
+
 - Update Traditional Chinese translation.
   [l34marr]
 

--- a/plone/app/dexterity/behaviors/tests/test_id.py
+++ b/plone/app/dexterity/behaviors/tests/test_id.py
@@ -1,3 +1,4 @@
+from DateTime import DateTime
 from plone.app.dexterity.testing import DEXTERITY_FUNCTIONAL_TESTING
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -80,14 +81,14 @@ class TestShortNameBehavior(unittest.TestCase):
         self.browser.getControl('Title').value = 'title'
         self.browser.getControl('Short name').value = 'foo'
         self.browser.getControl('Save').click()
-        mtime = self.layer['portal'].foo.bobobase_modification_time()
+        mtime = DateTime(self.layer['portal'].foo._p_mtime)
         self.browser.getLink('Edit').click()
         self.browser.getControl('Short name').value = 'foo'
         self.browser.getControl('Save').click()
         self.assertEqual(self.browser.url, 'http://nohost/plone/foo')
         # assert that object has not been modified
         self.assertEqual(
-            mtime, self.layer['portal'].foo.bobobase_modification_time()
+            mtime, DateTime(self.layer['portal'].foo._p_mtime)
         )
 
         behaviors = list(self.layer['portal'].portal_types.Document.behaviors)


### PR DESCRIPTION
No longer rely on deprecated bobobase_modification_time from Persistence.Persistent.

see changelog for Zope 4.0a1: https://github.com/zopefoundation/Zope/blob/master/CHANGES.rst