### PR TITLE
Avoid re-adding the UUID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Changelog
 - Update Brazil translations
   [claytonc]
 
+- Avoid re-adding the UUID on an upgrade step.
+  [gforcada]
 
 2.1.14 (2015-09-21)
 -------------------

--- a/plone/app/dexterity/tests/test_upgrades.py
+++ b/plone/app/dexterity/tests/test_upgrades.py
@@ -23,6 +23,8 @@ class TestUpgrades(unittest.TestCase):
         )
         setattr(page, ATTRIBUTE_NAME, None)
         self.assertTrue(IUUID(page, None) is None)
+        # reindex to remove the UUID it got when the page was created
+        page.reindexObject(idxs=['UID'])
 
         # run the migration
         add_missing_uuids(self.layer['portal'])

--- a/plone/app/dexterity/upgrades/to2001.py
+++ b/plone/app/dexterity/upgrades/to2001.py
@@ -8,8 +8,8 @@ from plone.uuid.interfaces import IUUID
 def add_missing_uuids(context):
     catalog = getToolByName(context, 'portal_catalog')
     query = {'object_provides': IDexterityContent.__identifier__}
-    for b in catalog.unrestrictedSearchResults(query):
-        ob = b.getObject()
+    for brain in catalog.unrestrictedSearchResults(query):
+        ob = brain.getObject()
         if IUUID(ob, None) is None:
             addAttributeUUID(ob, None)
             ob.reindexObject(idxs=['UID'])

--- a/plone/app/dexterity/upgrades/to2001.py
+++ b/plone/app/dexterity/upgrades/to2001.py
@@ -9,6 +9,8 @@ def add_missing_uuids(context):
     catalog = getToolByName(context, 'portal_catalog')
     query = {'object_provides': IDexterityContent.__identifier__}
     for brain in catalog.unrestrictedSearchResults(query):
+        if getattr(brain, 'UID', None) is not None:
+            continue
         ob = brain.getObject()
         if IUUID(ob, None) is None:
             addAttributeUUID(ob, None)


### PR DESCRIPTION
If an object already has a UID value on the catalog there is no need to add it again.

In cases where *LOTS* of objects get returned by the catalog call it can dramatically impact the upgrade.