### PR TITLE
Avoid re-adding the UUID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Avoid re-adding the UUID on an upgrade step.
+  [gforcada]
 
 
 2.0.16 (2015-09-28)

--- a/plone/app/dexterity/tests/test_upgrades.py
+++ b/plone/app/dexterity/tests/test_upgrades.py
@@ -22,6 +22,8 @@ class TestUpgrades(unittest.TestCase):
         )
         setattr(page, ATTRIBUTE_NAME, None)
         self.assertTrue(IUUID(page, None) is None)
+        # reindex to remove the UUID it got when the page was created
+        page.reindexObject(idxs=['UID'])
 
         # run the migration
         add_missing_uuids(self.layer['portal'])

--- a/plone/app/dexterity/upgrades/to2001.py
+++ b/plone/app/dexterity/upgrades/to2001.py
@@ -7,8 +7,8 @@ from plone.uuid.interfaces import IUUID
 def add_missing_uuids(context):
     catalog = getToolByName(context, 'portal_catalog')
     query = {'object_provides': IDexterityContent.__identifier__}
-    for b in catalog.unrestrictedSearchResults(query):
-        ob = b.getObject()
+    for brain in catalog.unrestrictedSearchResults(query):
+        ob = brain.getObject()
         if IUUID(ob, None) is None:
             addAttributeUUID(ob, None)
             ob.reindexObject(idxs=['UID'])

--- a/plone/app/dexterity/upgrades/to2001.py
+++ b/plone/app/dexterity/upgrades/to2001.py
@@ -8,6 +8,8 @@ def add_missing_uuids(context):
     catalog = getToolByName(context, 'portal_catalog')
     query = {'object_provides': IDexterityContent.__identifier__}
     for brain in catalog.unrestrictedSearchResults(query):
+        if getattr(brain, 'UID', None) is not None:
+            continue
         ob = brain.getObject()
         if IUUID(ob, None) is None:
             addAttributeUUID(ob, None)


### PR DESCRIPTION
If an object already has a UID value on the catalog there is no need to add it again.

In cases where *LOTS* of objects get returned by the catalog call it can dramatically impact the upgrade.

This pull request is a backports https://github.com/plone/plone.app.dexterity/pull/189 for 2.0.x line