### PR TITLE
Use plone i18n domain

### DIFF
--- a/plone/app/dexterity/__init__.py
+++ b/plone/app/dexterity/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import zope.i18nmessageid
+from zope.i18nmessageid import MessageFactory
 
-MessageFactory = zope.i18nmessageid.MessageFactory('plone.app.dexterity')
-PloneMessageFactory = zope.i18nmessageid.MessageFactory('plone')
+
+_ = MessageFactory('plone')

--- a/plone/app/dexterity/behaviors/configure.zcml
+++ b/plone/app/dexterity/behaviors/configure.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="plone.app.dexterity">
+    i18n_domain="plone">
 
   <include package="plone.behavior" file="meta.zcml"/>
 

--- a/plone/app/dexterity/behaviors/discussion.py
+++ b/plone/app/dexterity/behaviors/discussion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model

--- a/plone/app/dexterity/behaviors/exclfromnav.py
+++ b/plone/app/dexterity/behaviors/exclfromnav.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model

--- a/plone/app/dexterity/behaviors/id.py
+++ b/plone/app/dexterity/behaviors/id.py
@@ -2,7 +2,7 @@
 from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.locking.interfaces import ILockable

--- a/plone/app/dexterity/behaviors/metadata.py
+++ b/plone/app/dexterity/behaviors/metadata.py
@@ -3,8 +3,7 @@ from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from datetime import datetime
-from plone.app.dexterity import MessageFactory as _
-from plone.app.dexterity import PloneMessageFactory as _PMF
+from plone.app.dexterity import _
 from plone.app.z3cform.widget import AjaxSelectFieldWidget
 from plone.app.z3cform.widget import DatetimeFieldWidget
 from plone.app.z3cform.widget import SelectFieldWidget
@@ -65,13 +64,13 @@ class IBasic(model.Schema):
 
     # default fieldset
     title = schema.TextLine(
-        title=_PMF(u'label_title', default=u'Title'),
+        title=_(u'label_title', default=u'Title'),
         required=True
     )
 
     description = schema.Text(
-        title=_PMF(u'label_description', default=u'Summary'),
-        description=_PMF(
+        title=_(u'label_description', default=u'Summary'),
+        description=_(
             u'help_description',
             default=u'Used in item listings and search results.'
         ),
@@ -93,13 +92,13 @@ class ICategorization(model.Schema):
     # categorization fieldset
     model.fieldset(
         'categorization',
-        label=_PMF(u'label_schema_categorization', default=u'Categorization'),
+        label=_(u'label_schema_categorization', default=u'Categorization'),
         fields=['subjects', 'language'],
     )
 
     subjects = schema.Tuple(
-        title=_PMF(u'label_tags', default=u'Tags'),
-        description=_PMF(
+        title=_(u'label_tags', default=u'Tags'),
+        description=_(
             u'help_tags',
             default=u'Tags are commonly used for ad-hoc organization of ' +
                     u'content.'
@@ -115,7 +114,7 @@ class ICategorization(model.Schema):
     )
 
     language = schema.Choice(
-        title=_PMF(u'label_language', default=u'Language'),
+        title=_(u'label_language', default=u'Language'),
         vocabulary='plone.app.vocabularies.AvailableContentLanguages',
         required=False,
         missing_value='',
@@ -138,13 +137,13 @@ class IPublication(model.Schema):
     # dates fieldset
     model.fieldset(
         'dates',
-        label=_PMF(u'label_schema_dates', default=u'Dates'),
+        label=_(u'label_schema_dates', default=u'Dates'),
         fields=['effective', 'expires'],
     )
 
     effective = schema.Datetime(
-        title=_PMF(u'label_effective_date', u'Publishing Date'),
-        description=_PMF(
+        title=_(u'label_effective_date', u'Publishing Date'),
+        description=_(
             u'help_effective_date',
             default=u"If this date is in the future, the content will "
                     u"not show up in listings and searches until this date."),
@@ -153,8 +152,8 @@ class IPublication(model.Schema):
     directives.widget('effective', DatetimeFieldWidget)
 
     expires = schema.Datetime(
-        title=_PMF(u'label_expiration_date', u'Expiration Date'),
-        description=_PMF(
+        title=_(u'label_expiration_date', u'Expiration Date'),
+        description=_(
             u'help_expiration_date',
             default=u"When this date is reached, the content will no"
                     u"longer be visible in listings and searches."),
@@ -181,7 +180,7 @@ class IOwnership(model.Schema):
     # ownership fieldset
     model.fieldset(
         'ownership',
-        label=_PMF(
+        label=_(
             'label_schema_ownership',
             default=u'Ownership'
         ),
@@ -189,8 +188,8 @@ class IOwnership(model.Schema):
     )
 
     creators = schema.Tuple(
-        title=_PMF(u'label_creators', u'Creators'),
-        description=_PMF(
+        title=_(u'label_creators', u'Creators'),
+        description=_(
             u'help_creators',
             default=u"Persons responsible for creating the content of "
                     u"this item. Please enter a list of user names, one "
@@ -207,8 +206,8 @@ class IOwnership(model.Schema):
     )
 
     contributors = schema.Tuple(
-        title=_PMF(u'label_contributors', u'Contributors'),
-        description=_PMF(
+        title=_(u'label_contributors', u'Contributors'),
+        description=_(
             u'help_contributors',
             default=u"The names of people that have contributed "
                     u"to this item. Each contributor should "
@@ -224,8 +223,8 @@ class IOwnership(model.Schema):
     )
 
     rights = schema.Text(
-        title=_PMF(u'label_copyrights', default=u'Rights'),
-        description=_PMF(
+        title=_(u'label_copyrights', default=u'Rights'),
+        description=_(
             u'help_copyrights',
             default=u'Copyright statement or other rights information on this '
                     u'item.'

--- a/plone/app/dexterity/behaviors/nextprevious.py
+++ b/plone/app/dexterity/behaviors/nextprevious.py
@@ -3,7 +3,7 @@ from AccessControl import getSecurityManager
 from Acquisition import aq_base
 from zope.component import getUtility
 from Products.CMFCore.interfaces import IContentish
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.app.layout.nextprevious.interfaces import INextPreviousProvider
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider

--- a/plone/app/dexterity/browser/add_type.py
+++ b/plone/app/dexterity/browser/add_type.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.app.dexterity.interfaces import ITypeSettings
 from plone.dexterity.fti import DexterityFTI
 from plone.z3cform.layout import wrap_form

--- a/plone/app/dexterity/browser/behaviors.py
+++ b/plone/app/dexterity/browser/behaviors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from copy import deepcopy
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.app.dexterity.browser.layout import TypeFormLayout
 from plone.app.dexterity.interfaces import ITypeSchemaContext
 from plone.behavior.interfaces import IBehavior
@@ -11,10 +11,7 @@ from zope import schema
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import adapter
 from zope.component import getUtilitiesFor
-from zope.i18nmessageid import MessageFactory
 from zope.lifecycleevent import modified
-
-PMF = MessageFactory('plone')
 
 
 def behaviorConfigurationModified(object, event):
@@ -60,7 +57,7 @@ class TypeBehaviorsForm(form.EditForm):
     successMessage = _(u'Behaviors successfully updated.')
     noChangesMessage = _(u'No changes were made.')
     buttons = deepcopy(form.EditForm.buttons)
-    buttons['apply'].title = PMF(u'Save')
+    buttons['apply'].title = _(u'Save')
 
     def getContent(self):
         return BehaviorConfigurationAdapter(self.context)

--- a/plone/app/dexterity/browser/clone_type.py
+++ b/plone/app/dexterity/browser/clone_type.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.app.dexterity.interfaces import ITypeSettings
 from plone.dexterity.fti import DexterityFTI
 from plone.z3cform.layout import wrap_form

--- a/plone/app/dexterity/browser/configure.zcml
+++ b/plone/app/dexterity/browser/configure.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="plone.app.dexterity">
+    i18n_domain="plone">
 
   <!-- Default view for Dexterity types in Plone  4 -->
   <browser:page

--- a/plone/app/dexterity/browser/container.pt
+++ b/plone/app/dexterity/browser/container.pt
@@ -4,7 +4,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
       metal:use-macro="context/main_template/macros/master"
-      i18n:domain="plone.app.dexterity">
+      i18n:domain="plone">
 <body>
 
 <metal:main fill-slot="content-core">

--- a/plone/app/dexterity/browser/default_page_warning.pt
+++ b/plone/app/dexterity/browser/default_page_warning.pt
@@ -1,6 +1,6 @@
 <tal:info
  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
- i18n:domain="plone.app.dexterity">
+ i18n:domain="plone">
 <div class="portalMessage info" role="alertdialog" aria-labelledby="dialogTitle"
     tal:condition="context/@@plone_context_state/is_default_page|nothing">
   <strong id="dialogTitle"

--- a/plone/app/dexterity/browser/fields.py
+++ b/plone/app/dexterity/browser/fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.app.dexterity.browser.layout import TypeFormLayout
 from plone.schemaeditor.browser.schema.listing import ReadOnlySchemaListing
 from plone.schemaeditor.browser.schema.listing import SchemaListing

--- a/plone/app/dexterity/browser/import_types.py
+++ b/plone/app/dexterity/browser/import_types.py
@@ -8,7 +8,7 @@ from Products.GenericSetup.context import BaseContext
 from Products.GenericSetup.interfaces import IImportContext
 from cStringIO import StringIO
 from lxml import etree
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.namedfile.field import NamedFile
 from plone.z3cform.layout import wrap_form
 from z3c.form import field

--- a/plone/app/dexterity/browser/item.pt
+++ b/plone/app/dexterity/browser/item.pt
@@ -4,7 +4,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
       metal:use-macro="context/main_template/macros/master"
-      i18n:domain="plone.app.dexterity">
+      i18n:domain="plone">
 <body>
 
 <metal:main fill-slot="content-core">

--- a/plone/app/dexterity/browser/layout.py
+++ b/plone/app/dexterity/browser/layout.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone.app.dexterity import MessageFactory as _
+from plone.app.dexterity import _
 from plone.z3cform.layout import FormWrapper
 
 

--- a/plone/app/dexterity/browser/modeleditor.py
+++ b/plone/app/dexterity/browser/modeleditor.py
@@ -2,7 +2,7 @@
 from AccessControl import Unauthorized
 from Products.Five import BrowserView
 from lxml import etree
-from plone.schemaeditor import SchemaEditorMessageFactory as _
+from plone.app.dexterity import _
 from plone.supermodel.parser import SupermodelParseError
 from zope.component import queryMultiAdapter
 import json

--- a/plone/app/dexterity/browser/overview.pt
+++ b/plone/app/dexterity/browser/overview.pt
@@ -1,6 +1,6 @@
 <tal:form metal:use-macro="context/@@ploneform-macros/titlelessform"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    i18n:domain="plone.app.dexterity">
+    i18n:domain="plone">
 <tal:fields metal:fill-slot="fields">
   <tal:field tal:replace="structure view/widgets/title/@@ploneform-render-widget" />
   <tal:field tal:replace="structure view/widgets/description/@@ploneform-render-widget" />

--- a/plone/app/dexterity/browser/types_listing.pt
+++ b/plone/app/dexterity/browser/types_listing.pt
@@ -1,4 +1,5 @@
-<tal:root>
+<tal:root
+    i18n:domain="plone">
   <script type="text/javascript"
           tal:attributes="src context/++resource++schemaeditor.js"></script>
   <script type="text/javascript"
@@ -21,14 +22,12 @@
 
   <a class="pat-plone-modal"
       href="${context/absolute_url}/@@add-type">
-    <button i18n:domain="plone.app.dexterity"
-            i18n:translate="">Add New Content Type&hellip;</button>
+    <button i18n:translate="">Add New Content Type&hellip;</button>
   </a>
 
   <a class="pat-plone-modal"
       href="${context/absolute_url}/@@import-types">
-    <button i18n:domain="plone.app.dexterity"
-            i18n:translate="">Import Type Profiles&hellip;</button>
+    <button i18n:translate="">Import Type Profiles&hellip;</button>
   </a>
 
   <div class="crud-form"

--- a/plone/app/dexterity/browser/typesformwrapper.pt
+++ b/plone/app/dexterity/browser/typesformwrapper.pt
@@ -4,7 +4,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
       metal:use-macro="here/prefs_main_template/macros/master"
-      i18n:domain="plone.app.dexterity">
+      i18n:domain="plone">
 <body>
 <metal:main fill-slot="prefs_configlet_main">
 <tal:main-macro metal:define-macro="main">

--- a/plone/app/dexterity/configure.zcml
+++ b/plone/app/dexterity/configure.zcml
@@ -4,7 +4,7 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    i18n_domain="plone.app.dexterity">
+    i18n_domain="plone">
 
   <include package="plone.app.imaging" zcml:condition="installed plone.app.imaging"/>
   <include package="plone.app.vocabularies" />

--- a/plone/app/dexterity/events.zcml
+++ b/plone/app/dexterity/events.zcml
@@ -1,6 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    i18n_domain="plone.app.dexterity">
+    i18n_domain="plone">
 
   <!-- Register schema/field modify handlers -->
   <subscriber

--- a/plone/app/dexterity/locales/update.sh
+++ b/plone/app/dexterity/locales/update.sh
@@ -1,3 +1,0 @@
-domain=plone.app.dexterity
-i18ndude rebuild-pot --pot $domain.pot --merge $domain-manual.pot --create $domain ../
-i18ndude sync --pot $domain.pot */LC_MESSAGES/$domain.po

--- a/plone/app/dexterity/profiles/default/actions.xml
+++ b/plone/app/dexterity/profiles/default/actions.xml
@@ -2,7 +2,7 @@
 <object name="portal_actions" meta_type="Plone Actions Tool" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
   <object name="controlpanel" meta_type="CMF Action Category">
     <object name="controlpanel_addons" meta_type="CMF Action Category">
-      <object name="dexterity-types" meta_type="CMF Action" i18n:domain="plone.app.dexterity">
+      <object name="dexterity-types" meta_type="CMF Action" i18n:domain="plone">
         <property name="title" i18n:translate="">Dexterity Content Types</property>
         <property name="description" i18n:translate=""></property>
         <property name="url_expr">string:${portal_url}/@@dexterity-types</property>

--- a/plone/app/dexterity/profiles/default/controlpanel.xml
+++ b/plone/app/dexterity/profiles/default/controlpanel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<object name="portal_controlpanel" xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="plone.app.dexterity" purge="False">
+<object name="portal_controlpanel" xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="plone" purge="False">
   <configlet
       action_id="dexterity-types"
       appId="Plone"


### PR DESCRIPTION
plone.app.dexterity is an official Plone core package,
thus their translations belong to plone.app.locales.

This commit removes the plone.app.dexterity domain and changes it for
plone.

This fixes:
https://github.com/plone/plone.app.dexterity/issues/158

Needs to be merged together with https://github.com/plone/plone.schemaeditor/pull/35