### PR TITLE
Fix non existing self._request with schema.Choice value_type.

### DIFF
--- a/plone/app/dexterity/permissions.py
+++ b/plone/app/dexterity/permissions.py
@@ -90,3 +90,4 @@ class DXAddViewFieldPermissionChecker(DXFieldPermissionChecker):
             view = view.form_instance
         content = view.create({})
         self.context = content.__of__(view.context)
+        self._request = MockRequest()


### PR DESCRIPTION
I have this behavior:

```python
# -*- coding: utf-8 -*-
from plone.app.z3cform.widget import AjaxSelectFieldWidget
from plone.autoform import directives
from plone.autoform.interfaces import IFormFieldProvider
from plone.supermodel import model
from zope import schema
from zope.interface import provider
from . import _


@provider(IFormFieldProvider)
class IRelatedEmployees(model.Schema):

    employees = schema.Tuple(
        title=_(u'label_employees', default=u'Related employees'),
        description=_(
            u'help_employees',
            default=u'Related employees for this document.'
        ),
        value_type=schema.Choice(
            title=_(u'label_employees', default=u'Related employees'),
            vocabulary='zimmhrm.vocabularies.employees',
        ),
        required=False,
    )

    directives.widget(
        'employees',
        AjaxSelectFieldWidget,
        vocabulary='zimmhrm.vocabularies.employees'
    )
```
And this vocabulary:

```python
# -*- coding: utf-8 -*-
from Products.CMFCore.permissions import ModifyPortalContent
from plone import api
from plone.app.content.browser import vocabulary
from zope.interface.declarations import directlyProvides
from zope.schema.interfaces import IVocabularyFactory
from zope.schema.vocabulary import SimpleTerm
from zope.schema.vocabulary import SimpleVocabulary


vocabulary._permissions['zimmhrm.vocabularies.employees'] = ModifyPortalContent
vocabulary._permissions['zimmhrm.vocabularies.documenttypes'] = ModifyPortalContent  # noqa


def EmployeesVocabulary(context):
    terms = []
    for brain in api.content.find(portal_type='zimmhrm.employee'):
        terms.append(SimpleTerm(
            value=brain.UID,
            token=brain.UID.encode('utf-8'),
            title=brain.Title
        ))

    return SimpleVocabulary(terms)

directlyProvides(EmployeesVocabulary, IVocabularyFactory)
```

AjaxSelectFieldWidget fails to fetch terms cause of this failure:

```
2015-11-17 11:58:53 ERROR Zope.SiteErrorLog 1447757933.170.417949036274 http://plone.local:8080/Plone/dokumente/++add++File/@@getVocabulary
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module Products.PDBDebugMode.runcall, line 70, in pdb_runcall
  Module ZPublisher.Publish, line 48, in call_object
  Module plone.app.content.browser.vocabulary, line 76, in __call__
  Module plone.app.content.browser.vocabulary, line 207, in get_vocabulary
  Module plone.app.dexterity.permissions, line 60, in validate
AttributeError: 'DXAddViewFieldPermissionChecker' object has no attribute '_request'
> /home/pcdummy/.buildout/eggs/plone.app.dexterity-2.1.13-py2.7.egg/plone/app/dexterity/permissions.py(60)validate()
     59                                   resolveDottedName(widget) or widget)
---> 60                         widget = widget and widget(field, self._request)
     61                     else:
```

This small patch fixes that.