### PR TITLE
Overhaul of chapter form-schema-hints.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Fixes:
 
 Fixes:
 
+- Docs: Overhaul of chapter form-schema-hints.rst
+  [jensens]
+
 - Use the type ID in HTML classes in the type listing rather than titles.
   [davidjb]
 

--- a/docs/reference/form-schema-hints.rst
+++ b/docs/reference/form-schema-hints.rst
@@ -1,71 +1,82 @@
-Form schema hints
-==================
+Form Configuration with Schema Hints using Directives
+=====================================================
 
-**Directives which can be used to configure forms from schemata**
+Dexterity uses the directives in `plone.autoform`_ and `plone.supermodel`_ package to configure its `z3c.form`_-based add and edit forms.
 
-Dexterity uses the `plone.autoform`_ package to configure its
-`z3c.form`_-based add and edit forms. This allows a schema to be
-annotated with “form hints”, which are used to configure the form.
+A directive annotates a schema with “form hints”, which are used to configure the form when it gets generated from the schema.
 
-The easiest way to apply form hints in Python code is to use the
-directives from `plone.autoform` and `plone.supermodel`.
-For the directives to work, the schema
-must derive from *plone.supermodel.model.Schema*. Directives can be
-placed anywhere in the class body. By convention they are kept next to
-the fields they apply to.
+The easiest way to apply form hints in Python code is to use the directives from `plone.autoform` and `plone.supermodel`.
+For the directives to work, the schema must derive from *plone.supermodel.model.Schema*.
+
+Directives can be placed anywhere in the class body (annotations are made directly on the class).
+By convention they are kept next to the fields they apply to.
 
 For example, here is a schema that omits a field:
 
 .. code-block:: python
 
-    from plone.autoform import directives as form
+    from plone.autoform import directives
     from plone.supermodel import model
     from zope import schema
 
 
     class ISampleSchema(model.Schema):
 
-        title = schema.TextLine(title=u"Title")
+        title = schema.TextLine(title=u'Title')
 
-        form.omitted('additionalInfo')
+        directives.omitted('additionalInfo')
         additionalInfo = schema.Bytes()
 
-The form directives take parameters in the form of a list of field
-names, or a set of field name/value pairs as keyword arguments. Each
-directive can be used zero or more times.
+The form directives are taking parameters in the form of a list of field names,
+or a set of field name/value pairs as keyword arguments.
+Each directive can be used zero or more times.
 
-Form directives
----------------
+There are two kinds of directives:
 
-These form directives are included in the *plone.autoform.directives* module:
+- appereance related directives
+- security related directives
 
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Name            | Description                                                                                                                                                                                                                                                                                                                                  |
-+=================+==============================================================================================================================================================================================================================================================================================================================================+
-| widget          | Specify an alternate widget for a field. Pass the field name as a key and a widget as the value. The widget can either be a z3c.form widget instance or a string giving the dotted name to one.                                                                                                                                              |
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| omitted         | Omit one or more fields from forms. Takes a sequence of field names as parameters.                                                                                                                                                                                                                                                           |
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| mode            | Set the widget mode for one or more fields. Pass the field name as a key and the string ‘input’, ‘display’ or ‘hidden’ as the value.                                                                                                                                                                                                         |
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| order\_before   | Specify that a given field should be rendered before another. Pass the field name as a key and name of the other field as a value. If the other field is in a supplementary schema (i.e. one from a behaviour), its name will be e.g. “IOtherSchema.otherFieldName”. Alternatively, pass the string “\*” to put a field first in the form.   |
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| order\_after    | The inverse of order\_before(), putting a field after another. Passing “\*” will put the field at the end of the form.                                                                                                                                                                                                                       |
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-These form directives are included in the *plone.supermodel.directives* module:
+Appeareance Related Directives
+------------------------------
 
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| primary         | Designate a given field as the primary field in the schema. This is not used for form rendering, but is used for WebDAV marshaling of the content object.                                                                                                                                                                                    |
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| fieldset        | Creates a fieldset (rendered in Plone as a tab on the edit form).                                                                                                                                                                                                                                                                            |
-+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+*plone.autoform.directives* provides these:
+
+================= ======================================================================================================
+Name              Description
+================= ======================================================================================================
+widget            Specify an alternate widget for a field.
+                  Pass the field name as a key and a widget as the value.
+                  The widget can either be a z3c.form widget instance or a string giving the dotted name to one.
+omitted           Omit one or more fields from forms. Takes a sequence of field names as parameters.
+mode              Set the widget mode for one or more fields.
+                  Pass the field name as a key and the string ‘input’, ‘display’ or ‘hidden’ as the value.
+order\_before     Specify that a given field should be rendered before another.
+                  Pass the field name as a key and name of the other field as a value.
+                  If the other field is in a supplementary schema (i.e. one from a behaviour),
+                  its name will be e.g. “IOtherSchema.otherFieldName”.
+                  Alternatively, pass the string “\*” to put a field first in the form.
+order\_after      The inverse of order\_before(), putting a field after another.
+                  Passing “\*” will put the field at the end of the form.
+================= ======================================================================================================
+
+*plone.supermodel.directives* provides these:
+
+================= ======================================================================================================
+Name              Description
+================= ======================================================================================================
+fieldset          Creates a new (or reuses an existing) fieldset (rendered in Plone as a tab on the edit form).
+primary           Designate a given field as the primary field in the schema.
+                  This is not used for form rendering, but is used for WebDAV marshaling of the content object.
+================= ======================================================================================================
 
 The code sample below illustrates each of these directives:
 
 .. code-block:: python
 
-    from plone.autoform import directives as form
+    from plone.autoform import directives
+    from plone.supermodel.directives import fieldset
+    from plone.supermodel.directives import primary
     from plone.supermodel import model
     from plone.app.z3cform.wysiwyg import WysiwygFieldWidget
     from zope import schema
@@ -77,87 +88,91 @@ The code sample below illustrates each of these directives:
         # the 'footer' and 'dummy' fields. The label can be omitted if the
         # fieldset has already been defined.
 
-        form.fieldset('extra',
-                label=u"Extra information",
-                fields=['footer', 'dummy']
-            )
+        fieldset('extra',
+            label=u'Extra information',
+            fields=['footer', 'dummy']
+        )
 
         # Here a widget is specified as a dotted name.
-        # The body field is also designated as the priamry field for this schema
+        # The body field is also designated as the primary field for this schema
 
-        form.widget(body='plone.app.z3cform.wysiwyg.WysiwygFieldWidget')
-        model.primary('body')
+        directives.widget(body='plone.app.z3cform.wysiwyg.WysiwygFieldWidget')
+        primary('body')
         body = schema.Text(
-                title=u"Body text",
-                required=False,
-                default=u"Body text goes here"
-            )
+            title=u'Body text',
+            required=False,
+            default=u'Body text goes here'
+        )
 
         # The widget can also be specified as an object
 
-        form.widget(footer=WysiwygFieldWidget)
+        directives.widget(footer=WysiwygFieldWidget)
         footer = schema.Text(
-                title=u"Footer text",
-                required=False
-            )
+            title=u'Footer text',
+            required=False
+        )
 
-        # An omitted field. Use form.omitted('a', 'b', 'c') to omit several fields
+        # An omitted field.
+        # Use directives.omitted('a', 'b', 'c') to omit several fields
 
-        form.omitted('dummy')
+        directives.omitted('dummy')
         dummy = schema.Text(
-                title=u"Dummy"
-            )
+            title=u'Dummy'
+        )
 
         # A field in 'hidden' mode
 
-        form.mode(secret='hidden')
+        directives.mode(secret='hidden')
         secret = schema.TextLine(
-                title=u"Secret",
-                default=u"Secret stuff"
-            )
+            title=u'Secret',
+            default=u'Secret stuff'
+        )
 
         # This field is moved before the 'description' field of the standard
         # IBasic behaviour, if this is in use.
 
-        form.order_before(importantNote='IBasic.description')
+        directives.order_before(importantNote='IBasic.description')
         importantNote = schema.TextLine(
-                title=u"Important note",
-            )
+            title=u'Important note',
+        )
 
-Security directives
--------------------
+Security related directives
+---------------------------
 
-The security directives in the *plone.autoform.directives* module are
-shown below. Note that these are also used to control reading and
-writing of fields on content instances.
+The security directives in the *plone.autoform.directives* module are shown below.
+Note that these are also used to control reading and writing of fields on content instances.
 
-+---------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Name                | Description                                                                                                                                                                                                                          |
-+=====================+======================================================================================================================================================================================================================================+
-| read\_permission    | Set the (Zope 3) name of a permission required to read the field’s value. Pass the field name as a key and the permission name as a string value. Among other things, this controls the field’s appearance in display forms.         |
-+---------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| write\_permission   | Set the (Zope 3) name of a permission required to write the field’s value. Pass the field name as a key and the permission name as a string value. Among other things, this controls the field’s appearance in add and edit forms.   |
-+---------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+==================== =================================================================================
+Name                 Description
+==================== =================================================================================
+read\_permission     Set the name (zcml-style) of a permission required to read the field’s value.
+                     Pass the field name as a key and the permission name as a string value.
+                     Among other things, this controls the field’s appearance in display forms.
+write\_permission    Set the name (zcml-style)  of a permission required to write the field’s value.
+                     Pass the field name as a key and the permission name as a string value.
+                     Among other things, this controls the field’s appearance in add and edit forms.
+==================== =================================================================================
 
 The code sample below illustrates each of these directives:
 
 .. code-block:: python
 
-    from plone.autoform import directives as form
+    from plone.autoform import directives
     from plone.supermodel import model
     from zope import schema
 
     class ISampleSchema(model.Schema):
 
-        # This field requires the 'cmf.ReviewPortalContent' to be read and
-        # written
+        # This field requires the 'cmf.ReviewPortalContent' permission
+        # to be read and written
 
-        form.read_permission(reviewNotes='cmf.ReviewPortalContent')
-        form.write_permission(reviewNotes='cmf.ReviewPortalContent')
+        directives.read_permission(reviewNotes='cmf.ReviewPortalContent')
+        directives.write_permission(reviewNotes='cmf.ReviewPortalContent')
         reviewNotes = schema.Text(
-                title=u"Review notes",
-                required=False,
-            )
+            title=u'Review notes',
+            required=False,
+        )
 
 .. _plone.autoform: http://pypi.python.org/pypi/plone.autoform
+.. _plone.supermodel: http://pypi.python.org/pypi/plone.supermodel
 .. _z3c.form: http://docs.zope.org/z3c.form

--- a/docs/reference/form-schema-hints.rst
+++ b/docs/reference/form-schema-hints.rst
@@ -1,11 +1,10 @@
 Form Configuration with Schema Hints using Directives
 =====================================================
 
-Dexterity uses the directives in `plone.autoform`_ and `plone.supermodel`_ package to configure its `z3c.form`_-based add and edit forms.
-
+Dexterity uses the directives in `plone.autoform <http://pypi.python.org/pypi/plone.autoform>`_ and `plone.supermodel <http://pypi.python.org/pypi/plone.supermodel>`_ package to configure its `z3c.form <http://docs.zope.org/z3c.form>`_-based add and edit forms.
 A directive annotates a schema with “form hints”, which are used to configure the form when it gets generated from the schema.
 
-The easiest way to apply form hints in Python code is to use the directives from `plone.autoform` and `plone.supermodel`.
+The easiest way to apply form hints in Python code is to use the directives from `plone.autoform <http://pypi.python.org/pypi/plone.autoform>`_ and `plone.supermodel <http://pypi.python.org/pypi/plone.supermodel>`_.
 For the directives to work, the schema must derive from *plone.supermodel.model.Schema*.
 
 Directives can be placed anywhere in the class body (annotations are made directly on the class).
@@ -33,11 +32,11 @@ Each directive can be used zero or more times.
 
 There are two kinds of directives:
 
-- appereance related directives
+- appearance related directives
 - security related directives
 
 
-Appeareance Related Directives
+Appearance Related Directives
 ------------------------------
 
 *plone.autoform.directives* provides these:
@@ -53,7 +52,7 @@ mode              Set the widget mode for one or more fields.
                   Pass the field name as a key and the string ‘input’, ‘display’ or ‘hidden’ as the value.
 order\_before     Specify that a given field should be rendered before another.
                   Pass the field name as a key and name of the other field as a value.
-                  If the other field is in a supplementary schema (i.e. one from a behaviour),
+                  If the other field is in a supplementary schema (i.e. one from a behavior),
                   its name will be e.g. “IOtherSchema.otherFieldName”.
                   Alternatively, pass the string “\*” to put a field first in the form.
 order\_after      The inverse of order\_before(), putting a field after another.
@@ -129,7 +128,7 @@ The code sample below illustrates each of these directives:
         )
 
         # This field is moved before the 'description' field of the standard
-        # IBasic behaviour, if this is in use.
+        # IBasic behavior, if this is in use.
 
         directives.order_before(importantNote='IBasic.description')
         importantNote = schema.TextLine(
@@ -173,6 +172,3 @@ The code sample below illustrates each of these directives:
             required=False,
         )
 
-.. _plone.autoform: http://pypi.python.org/pypi/plone.autoform
-.. _plone.supermodel: http://pypi.python.org/pypi/plone.supermodel
-.. _z3c.form: http://docs.zope.org/z3c.form


### PR DESCRIPTION
- fixed: historic and confusing ``... import directives as from`` changed.
- fixed: wrong usage of ``primary`` and ``fieldset`` corrected.
- overhaul: introduction
- overhaul: table style 
- overhaul: code style

/cc @svx @polyester may you have a quick look?
