### PR TITLE
The defaults of exclude from navigation is now obtained from an adapter.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.2.1 (unreleased)
+2.3.0 (unreleased)
 ------------------
 
 Breaking changes:
@@ -10,7 +10,10 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- The defaults of exclude from navigation is no obtained from an adapter.
+  It still defaults to False. An alternative adapter which defaults to True is
+  provided but not registered. Custom adapters are possible too.
+  [jensens]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,10 @@ Breaking changes:
 
 New features:
 
-- The defaults of exclude from navigation is no obtained from an adapter.
-  It still defaults to False. An alternative adapter which defaults to True is
-  provided but not registered. Custom adapters are possible too.
+- The defaults of exclude from navigation is now obtained from a contextaware default factory, which value is obtained from an adapter.
+  The default adapter returns False.
+  An alternative adapter which defaults to True is provided but not registered.
+  This change makes it possible to provide a custom context specific implementation.
   [jensens]
 
 Bug fixes:

--- a/plone/app/dexterity/behaviors/configure.zcml
+++ b/plone/app/dexterity/behaviors/configure.zcml
@@ -88,6 +88,10 @@
       description="Allow items to be excluded from navigation"
       provides=".exclfromnav.IExcludeFromNavigation"
       />
+  <adapter
+      for="*"
+      factory=".exclfromnav.default_exclude_false"
+      />
 
   <!-- Next previous -->
   <plone:behavior

--- a/plone/app/dexterity/behaviors/exclfromnav.py
+++ b/plone/app/dexterity/behaviors/exclfromnav.py
@@ -6,7 +6,36 @@ from plone.supermodel import model
 from z3c.form.interfaces import IAddForm
 from z3c.form.interfaces import IEditForm
 from zope import schema
+from zope.interface import implementer
+from zope.interface import Interface
 from zope.interface import provider
+from zope.schema.interfaces import IContextAwareDefaultFactory
+
+
+class IExcludeFromNavigationDefault(Interface):
+
+    def __call__():
+        """boolean if item is by default excluded from navigation or not.
+        """
+
+
+@implementer(IExcludeFromNavigationDefault)
+def default_exclude_false(context):
+    """provide a default adapter with the standard uses
+    """
+    return False
+
+
+@implementer(IExcludeFromNavigationDefault)
+def default_exclude_true(context):
+    """provide a alternative adapter with opposite default as standard
+    """
+    return True
+
+
+@provider(IContextAwareDefaultFactory)
+def default_exclude(context):
+    return IExcludeFromNavigationDefault(context)
 
 
 @provider(IFormFieldProvider)
@@ -27,10 +56,10 @@ class IExcludeFromNavigation(model.Schema):
         ),
         description=_(
             u'help_exclude_from_nav',
-            default=u'If selected, this item will not appear in the ' +
+            default=u'If selected, this item will not appear in the '
                     u'navigation tree'
         ),
-        default=False
+        defaultFactory=default_exclude,
     )
 
     directives.omitted('exclude_from_nav')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.2.1.dev0'
+version = '2.3.0.dev0'
 long_description = open("README.rst").read() + "\n" + \
     open("RELEASE_NOTES.rst").read() + "\n" + \
     open("CHANGES.rst").read()


### PR DESCRIPTION
It still defaults to ``False``. An alternative adapter which defaults to ``True`` is provided but not registered. 

Custom adapters are possible too.