### PR TITLE
Linebreaks in description are replaced with a space ...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Linebreaks in description are replaced with a space instead of vanishing it.
+  Thus an editor can use them w/o having word glued together afterwards.
+  [jensens]
 
 
 2.2.0 (2016-04-28)

--- a/plone/app/dexterity/behaviors/metadata.py
+++ b/plone/app/dexterity/behaviors/metadata.py
@@ -368,10 +368,11 @@ class Basic(MetadataBase):
         # See http://bo.geekworld.dk/diazo-bug-on-html5-validation-errors/
 
         if '\n' in value:
-            value = value.replace('\n', '')
-
-        if '\r' in value:
-            value = value.replace('\r', '')
+            value = value.replace('\n', ' ')
+            if '\r' in value:
+                value = value.replace('\r', '')
+        elif '\r' in value:
+            value = value.replace('\r', ' ')
 
         self.context.description = value
 


### PR DESCRIPTION
... instead of vanishing it.