### PR TITLE
TTW behaviors selection of the name is now bound to the registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- TTW behaviors selection of the name is now bound to the registration,
+  prior it was bound to the interface.
+  But interfaces may be used by more than one registered behavior.
+  [jensens]
 
 
 2.3.2 (2016-08-12)

--- a/plone/app/dexterity/browser/behaviors.py
+++ b/plone/app/dexterity/browser/behaviors.py
@@ -91,14 +91,14 @@ class TypeBehaviorsForm(form.EditForm):
     @property
     def fields(self):
         counts = Counter(
-            [reg.interface for name, reg in getUtilitiesFor(IBehavior)]
+            [id(reg) for name, reg in getUtilitiesFor(IBehavior)]
         )
         fields = []
         for name, reg in getUtilitiesFor(IBehavior):
             if name in TTW_BEHAVIOR_BLACKLIST:
                 # skip blacklisted
                 continue
-            with_name = counts[reg.interface] == 2
+            with_name = counts[id(reg)] > 1
             if with_name and reg.name != name:
                 continue
             fname = reg.name if reg.name else name


### PR DESCRIPTION
TTW behaviors selection of the name is now bound to the registration, prior it was bound to the interface.  But interfaces may be used by more than one registered behavior.
