### PR TITLE
Add example of testing a dexterity type using a behavior. fix #229

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Bug fixes:
 - Update code to follow Plone styleguide.
   [gforcada]
 
+- Documentation: Add dexterity test example using a behavior.
+  [ramiroluz]
+
 2.3.4 (2016-10-03)
 ------------------
 

--- a/docs/behaviors/testing-behaviors.rst
+++ b/docs/behaviors/testing-behaviors.rst
@@ -239,7 +239,12 @@ Lets say you want to test your dexterity type when a behavior is enabled or disa
             self.assertNotIn('<meta http-equiv="refresh" content="5" />', view())
 
 
-The methods ``_enable_refresh_behavior`` and ``_disable_refresh_behavior`` are using the ``IDexterityFTI``, to get the Factory Type Information for the dexterity type, in this case ``collective.cover.content``. Then the FTI of ``collective.cover.content`` is used by both methods to get a list of behaviors enabled. To enable it the desired behavior it is added to the FTI behaviors, ``behaviors.append(IRefresh.__identifier__)``. To disable it the behavior is removed from the FTI behaviors, ``behaviors.remove(IRefresh.__identifier__)``. The resulting behaviors list is assigned to the behaviors attribute of the FTI as a tuple, ``fti.behaviors = tuple(behaviors)``. Finally, to make the changes effective, the schema cache must be invalidated, ``notify(SchemaInvalidatedEvent('collective.cover.content'))``.
+The methods ``_enable_refresh_behavior`` and ``_disable_refresh_behavior`` are using the ``IDexterityFTI``, to get the Factory Type Information for the dexterity type, in this case ``collective.cover.content``.
+Then the FTI of ``collective.cover.content`` is used by both methods to get a list of behaviors enabled.
+To enable it the desired behavior it is added to the FTI behaviors, ``behaviors.append(IRefresh.__identifier__)``.
+To disable it the behavior is removed from the FTI behaviors, ``behaviors.remove(IRefresh.__identifier__)``.
+The resulting behaviors list is assigned to the behaviors attribute of the FTI as a tuple, ``fti.behaviors = tuple(behaviors)``.
+Finally, to make the changes effective, the schema cache must be invalidated, ``notify(SchemaInvalidatedEvent('collective.cover.content'))``.
 
 A note about marker interfaces
 ------------------------------

--- a/docs/behaviors/testing-behaviors.rst
+++ b/docs/behaviors/testing-behaviors.rst
@@ -8,11 +8,11 @@ If you are writing a behavior with just a marker interface or schema interface, 
 However, any actual code, such as a behavior adapter factory, ought to be tested.
 
 Writing a behavior integration test is not very difficult if you are happy to depend on Dexterity in your test.
-You can create a dummy type by instantiating a Dexterty FTI in *portal\_types*.
-Then enable your behavior by adding its interface name to the *behaviors* property.
+You can create a dummy type by instantiating a Dexterity FTI in *portal\_types*.
+Then, enable your behavior by adding its interface name to the *behaviors* property.
 
 In many cases, however, it is better not to depend on Dexterity at all.
-It is not too difficult to mock what Dexterity does to enable behaviors on its types.
+It is not too difficult to mimic what Dexterity does to enable behaviors on its types.
 The following example is taken from *collective.gtags* and tests the *ITags* behavior we saw on the first page of this manual.
 
 ::
@@ -119,8 +119,8 @@ The following example is taken from *collective.gtags* and tests the *ITags* beh
         True
 
 This test tries to prove that the behavior is correctly installed and works as intended on a suitable content class.
-It is not a true unit test, of course.
-For that, we would simply test the *Tags* adapter directly on a dummy context, but that is not terribly interesting, since all it does is convert sets to tuples.
+It is not a true unit test, however.
+For a true unit test, we would simply test the *Tags* adapter directly on a dummy context, but that is not terribly interesting, since all it does is convert sets to tuples.
 
 First, we configure the package.
 To keep the test small, we limit ourselves to the *behaviors.zcml* file, which in this case will suffice.
@@ -134,14 +134,14 @@ supported behaviors.
 With this in place, we first check that the *IBehavior* utility has been correctly registered.
 This is essentially a test to show that we’ve used the *<plone:behavior />* directive as intended.
 We also verify that our schema interface is an *IFormFieldsProvider*.
-For a non-form behavior, we’d obviously omit this.
+For a non-form behavior, we’d omit this.
 
 Finally, we test the behavior.
 We’ve chosen to use CMFDefault’s *Document* type for our test, as the behavior adapter requires an object providing *IDublinCore*.
-If we were less lazy, we’d write our own class and implement *IDublinCore* directly.
+Ideally, we’d write our own class and implement *IDublinCore* directly.
 However, in many cases, the types from CMFDefault are going to provide convenient test fodder.
 
-Obviously, if our behavior was more complex, we’d add more intricate tests.
+If our behavior was more complex we’d add more intricate tests.
 By the last section of the doctest, we have enough context to test the adapter factory.
 
 To run the test, we need a test suite. In *tests.py*, we have:
@@ -176,7 +176,13 @@ To run the test, we can use the usual test runner:
 Testing a dexterity type with a behavior
 ----------------------------------------
 
-Lets say you want to test your dexterity type when a behavior is enabled or disabled, note that not all behaviors are enabled by default. To do this you will need to setup the behavior in your test. There is an example of this kind of test in the collective.cover product. There is a behavior that adds the capability for the cover page to refresh itself. The test check to see if the behavior effect on the page is not present, then enables the behavior, check its effect and then disables it again. Here is the code:
+Not all behaviors are enabled by default.
+Let's say you want to test your Dexterity type when a behavior is enabled or disabled.
+To do this, you will need to setup the behavior in your test.
+There is an example of this kind of test in the collective.cover product.
+There is a behavior that adds the capability for the cover page to refresh itself.
+The test checks if the behavior is not yet enabled, enables the behavior, check its effect and then disables it again.
+Here is the code:
 
 .. code-block:: python
 
@@ -239,15 +245,15 @@ Lets say you want to test your dexterity type when a behavior is enabled or disa
             self.assertNotIn('<meta http-equiv="refresh" content="5" />', view())
 
 
-The methods ``_enable_refresh_behavior`` and ``_disable_refresh_behavior`` are using the ``IDexterityFTI``, to get the Factory Type Information for the dexterity type, in this case ``collective.cover.content``.
-Then the FTI of ``collective.cover.content`` is used by both methods to get a list of behaviors enabled.
-To enable it the desired behavior it is added to the FTI behaviors, ``behaviors.append(IRefresh.__identifier__)``.
-To disable it the behavior is removed from the FTI behaviors, ``behaviors.remove(IRefresh.__identifier__)``.
-The resulting behaviors list is assigned to the behaviors attribute of the FTI as a tuple, ``fti.behaviors = tuple(behaviors)``.
-Finally, to make the changes effective, the schema cache must be invalidated, ``notify(SchemaInvalidatedEvent('collective.cover.content'))``.
+The methods ``_enable_refresh_behavior`` and ``_disable_refresh_behavior`` use the ``IDexterityFTI`` to get the Factory Type Information for the Dexterity type (``collective.cover.content`` in this case).
+Then the FTI of ``collective.cover.content`` is used by both methods to get a list of enabled behaviors.
+To enable it, add the desired behavior to the FTI behaviors: ``behaviors.append(IRefresh.__identifier__)``.
+To disable it, remove the behavior from the FTI behaviors: ``behaviors.remove(IRefresh.__identifier__)``.
+Assign the resulting behaviors list to the behaviors attribute of the FTI as a tuple: ``fti.behaviors = tuple(behaviors)``.
+Finally, to have the changes take effect, invalidate the schema cache: ``notify(SchemaInvalidatedEvent('collective.cover.content'))``.
 
 A note about marker interfaces
 ------------------------------
 
-Note that marker interface support depends on code that is implemented in Dexterity and is non-trivial to reproduce in a test.
+Marker interface support depends on code that is implemented in Dexterity and is non-trivial to reproduce in a test.
 If you need a marker interface in a test, set it manually with *zope.interface.alsoProvides*, or write an integration test with Dexterity content.


### PR DESCRIPTION
I believe it works in Plone 5 and Plone 4.