### PR TITLE
Add generic version of folder_listing view & macro

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Bug fixes:
 - Documentation: Add dexterity test example using a behavior.
   [ramiroluz]
 
-- For Plone 5.1, add a generic version of the folder_listing view
+- Add a generic version of the folder_listing view
   so that the container view can use it even without plone.app.contenttypes
   (such as in tests using the DEXTERITY_FIXTURE)
   [davisagli]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,8 +20,8 @@ Bug fixes:
 - Documentation: Add dexterity test example using a behavior.
   [ramiroluz]
 
-- Add a generic version of the folder_listing view so that
-  the container view can use it even without plone.app.contenttypes
+- For Plone 5.1, add a generic version of the folder_listing view
+  so that the container view can use it even without plone.app.contenttypes
   (such as in tests using the DEXTERITY_FIXTURE)
   [davisagli]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ Bug fixes:
 - Documentation: Add dexterity test example using a behavior.
   [ramiroluz]
 
+- Add a generic version of the folder_listing view so that
+  the container view can use it even without plone.app.contenttypes
+  (such as in tests using the DEXTERITY_FIXTURE)
+  [davisagli]
+
+
 2.3.4 (2016-10-03)
 ------------------
 

--- a/plone/app/dexterity/browser/configure.zcml
+++ b/plone/app/dexterity/browser/configure.zcml
@@ -21,9 +21,17 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="plone.dexterity.interfaces.IDexterityContainer"
+      name="folder_listing"
+      class=".folder_listing.FolderView"
+      template="folder_listing.pt"
+      permission="zope2.View"
+      />
+
   <configure zcml:condition="have plone-51">
     <browser:page
-        for="Products.CMFCore.interfaces.IFolderish"
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
         name="folder_listing"
         class=".folder_listing.FolderView"
         template="folder_listing.pt"

--- a/plone/app/dexterity/browser/configure.zcml
+++ b/plone/app/dexterity/browser/configure.zcml
@@ -21,13 +21,15 @@
       permission="zope2.View"
       />
 
-  <browser:page
-      for="Products.CMFCore.interfaces.IFolderish"
-      name="folder_listing"
-      class=".folder_listing.FolderView"
-      template="folder_listing.pt"
-      permission="zope2.View"
-      />
+  <configure zcml:condition="have plone-51">
+    <browser:page
+        for="Products.CMFCore.interfaces.IFolderish"
+        name="folder_listing"
+        class=".folder_listing.FolderView"
+        template="folder_listing.pt"
+        permission="zope2.View"
+        />
+  </configure>
 
   <!-- warning when editing default pages -->
   <browser:viewlet

--- a/plone/app/dexterity/browser/configure.zcml
+++ b/plone/app/dexterity/browser/configure.zcml
@@ -21,6 +21,14 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="Products.CMFCore.interfaces.IFolderish"
+      name="folder_listing"
+      class=".folder_listing.FolderView"
+      template="folder_listing.pt"
+      permission="zope2.View"
+      />
+
   <!-- warning when editing default pages -->
   <browser:viewlet
       name="plone.app.dexterity.defaultpagewarning"

--- a/plone/app/dexterity/browser/folder_listing.pt
+++ b/plone/app/dexterity/browser/folder_listing.pt
@@ -1,0 +1,117 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    lang="en"
+    metal:use-macro="context/main_template/macros/master"
+    i18n:domain="plone">
+<body>
+
+<metal:content-core fill-slot="content-core">
+<metal:block define-macro="content-core">
+
+  <metal:listingmacro define-macro="listing">
+    <tal:results define="batch view/batch">
+      <tal:listing condition="batch">
+        <div class="entries" metal:define-slot="entries">
+          <tal:repeat repeat="item batch" metal:define-macro="entries">
+            <tal:block tal:define="obj item/getObject;
+                item_url item/getURL;
+                item_id item/getId;
+                item_title item/Title;
+                item_description item/Description;
+                item_type item/PortalType;
+                item_modified item/ModificationDate;
+                item_created item/CreationDate;
+                item_type_class python:'contenttype-' + view.normalizeString(item_type);
+                item_wf_state item/review_state;
+                item_wf_state_class python:'state-' + view.normalizeString(item_wf_state);
+                item_creator item/Creator;
+                item_link python:item_type in view.use_view_action and item_url+'/view' or item_url;
+                item_has_image python:item.getIcon">
+              <metal:block define-slot="entry">
+                <article class="entry">
+                  <header metal:define-macro="listitem">
+                    <span class="summary" tal:attributes="title item_type">
+                     <a tal:attributes="href item_link">
+                      <img class="image-tile"
+                             tal:condition="item_has_image"
+                             tal:attributes="src  string:$item_url/@@images/image/tile">
+                      </a>
+                      <a tal:attributes="href item_link;
+                                         class string:$item_type_class $item_wf_state_class url;
+                                         title item_type"
+                          tal:content="item_title">
+
+                             Item Title
+                      </a>
+                     </span>
+                    <metal:block metal:define-macro="document_byline">
+                      <div class="documentByLine">
+                        <tal:byline condition="view/show_about">
+                          &mdash;
+                          <tal:name tal:condition="item_creator"
+                              tal:define="author python:view.pas_member.info(item_creator);
+                                          creator_short_form author/username;
+                                          creator_long_form string:?author=${author/username};
+                                          creator_is_openid python:'/' in creator_short_form;
+                                          creator_id python:(creator_short_form, creator_long_form)[creator_is_openid];">
+                          <span i18n:translate="label_by_author">
+                            by
+                            <a tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
+                                tal:content="author/name_or_id"
+                                tal:omit-tag="not:author"
+                                i18n:name="author">
+                              Bob Dobalina
+                            </a>
+                          </span>
+                          </tal:name>
+
+                          <tal:modified>
+                            &mdash;
+                            <tal:mod i18n:translate="box_last_modified">last modified</tal:mod>
+                            <span tal:replace="python:view.toLocalizedTime(item_modified,long_format=1)">
+                              August 16, 2001 at 23:35:59
+                            </span>
+                          </tal:modified>
+
+                          <metal:description define-slot="description_slot">
+                            <tal:comment replace="nothing">
+                              Place custom listing info for custom types here
+                            </tal:comment>
+                          </metal:description>
+                        </tal:byline>
+                      </div>
+                    </metal:block>
+                  </header>
+                  <p class="description discreet"
+                      tal:condition="item_description"
+                      tal:content="item_description">
+                    description
+                  </p>
+                </article>
+              </metal:block>
+            </tal:block>
+          </tal:repeat>
+        </div>
+
+        <div metal:use-macro="context/batch_macros/macros/navigation" />
+
+      </tal:listing>
+
+      <metal:empty metal:define-slot="no_items_in_listing">
+        <p class="discreet"
+            tal:condition="not: view/batch"
+            tal:content="view/no_items_message">
+          There are currently no items in this folder.
+        </p>
+      </metal:empty>
+
+    </tal:results>
+  </metal:listingmacro>
+
+</metal:block>
+</metal:content-core>
+
+</body>
+</html>

--- a/plone/app/dexterity/browser/folder_listing.py
+++ b/plone/app/dexterity/browser/folder_listing.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from Acquisition import aq_inner
+from plone.app.dexterity import _
+from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import ISecuritySchema
+from Products.CMFPlone.PloneBatch import Batch
+from Products.Five import BrowserView
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+
+
+class FolderView(BrowserView):
+
+    def __init__(self, context, request):
+        super(FolderView, self).__init__(context, request)
+
+        self.plone_view = getMultiAdapter(
+            (context, request), name=u'plone')
+        self.portal_state = getMultiAdapter(
+            (context, request), name=u'plone_portal_state')
+        self.pas_member = getMultiAdapter(
+            (context, request), name=u'pas_member')
+
+        limit_display = getattr(self.request, 'limit_display', None)
+        limit_display = int(limit_display) if limit_display is not None else 20
+        b_size = getattr(self.request, 'b_size', None)
+        self.b_size = int(b_size) if b_size is not None else limit_display
+        b_start = getattr(self.request, 'b_start', None)
+        self.b_start = int(b_start) if b_start is not None else 0
+
+    def results(self, **kwargs):
+        """Return a content listing based result set with contents of the
+        folder.
+
+        :param **kwargs: Any keyword argument, which can be used for catalog
+                         queries.
+        :type  **kwargs: keyword argument
+
+        :returns: plone.app.contentlisting based result set.
+        :rtype: ``plone.app.contentlisting.interfaces.IContentListing`` based
+                sequence.
+        """
+        # Extra filter
+        kwargs.update(self.request.get('contentFilter', {}))
+        if 'object_provides' not in kwargs:  # object_provides is more specific
+            kwargs.setdefault('portal_type', self.friendly_types)
+        kwargs.setdefault('batch', True)
+        kwargs.setdefault('b_size', self.b_size)
+        kwargs.setdefault('b_start', self.b_start)
+
+        listing = aq_inner(self.context).restrictedTraverse(
+            '@@folderListing', None)
+        if listing is None:
+            return []
+        results = listing(**kwargs)
+        return results
+
+    def batch(self):
+        batch = Batch(
+            self.results(),
+            size=self.b_size,
+            start=self.b_start,
+            orphan=1
+        )
+        return batch
+
+    def normalizeString(self, text):
+        return self.plone_view.normalizeString(text)
+
+    def toLocalizedTime(self, time, long_format=None, time_only=None):
+        return self.plone_view.toLocalizedTime(time, long_format, time_only)
+
+    @property
+    def friendly_types(self):
+        return self.portal_state.friendly_types()
+
+    @property
+    def isAnon(self):
+        return self.portal_state.anonymous()
+
+    @property
+    def navigation_root_url(self):
+        return self.portal_state.navigation_root_url()
+
+    @property
+    def use_view_action(self):
+        registry = getUtility(IRegistry)
+        return registry.get('plone.types_use_view_action_in_listings', [])
+
+    @property
+    def show_about(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISecuritySchema, prefix='plone')
+        show_about = getattr(settings, 'allow_anon_views_about', False)
+        return show_about or not self.isAnon
+
+    @property
+    def no_items_message(self):
+        return _(
+            'description_no_items_in_folder',
+            default=u'There are currently no items in this folder.'
+        )


### PR DESCRIPTION
This is a necessary counterpart to https://github.com/plone/Products.CMFPlone/pull/1839 and https://github.com/plone/Products.ATContentTypes/pull/39 to move content views from the plone_content layer in CMFPlone to ATContentTypes.

The Dexterity container view looks for the folder_listing view to get the macro for rendering contained items, so we need this to be present even if ATContentTypes or plone.app.contenttypes aren't installed (such as in tests)