### PR TITLE
Do not remove newlines in description setter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,14 @@
 Changelog
 =========
 
-2.3.7 (unreleased)
+2.4.0 (unreleased)
 ------------------
 
 Breaking changes:
 
-- *add item here*
+- When setting the Description field, do not remove new lines but keep the input as-is.
+  Instead remove new lines in the plone.dexterity ``Description`` metadata accessor.
+  [thet]
 
 New features:
 

--- a/plone/app/dexterity/behaviors/metadata.py
+++ b/plone/app/dexterity/behaviors/metadata.py
@@ -365,12 +365,6 @@ class Basic(MetadataBase):
         if isinstance(value, str):
             raise ValueError('Description must be unicode.')
 
-        # If description is containing linefeeds the HTML
-        # validation can break.
-        # See http://bo.geekworld.dk/diazo-bug-on-html5-validation-errors/
-        # Remember: \r\n - Windows, \r - OS X, \n - Linux/Unix
-        value = value.replace('\r\n', ' ').replace('\r', ' ').replace('\n', ' ')  # noqa
-
         self.context.description = value
 
     description = property(_get_description, _set_description)

--- a/plone/app/dexterity/behaviors/tests/test_metadata.py
+++ b/plone/app/dexterity/behaviors/tests/test_metadata.py
@@ -39,6 +39,11 @@ class TestBasic(unittest.TestCase):
         b.context.description = u'foo'
         self.assertEqual(u'foo', b.description)
 
+    def test_description_remains_newlines(self):
+        b = self._makeOne()
+        b.description = u'foo\r\nbar\nbaz\r'
+        self.assertEqual(u'foo\r\nbar\nbaz\r', b.context.description)
+
 
 class TestCategorization(unittest.TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '2.3.7.dev0'
+version = '2.4.0.dev0'
 
 short_description = (
     'Dexterity is a content type framework for CMF  applications, '


### PR DESCRIPTION
When setting the Description field, do not remove new lines but keep the input as-is.
Instead remove new lines in the plone.dexterity ``Description`` metadata accessor.