### PR TITLE
Fix permission check for add forms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,14 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Cleanup code of ``permissions.py`` (ZCA-decorator, reduce complexity)
+  [jensens]
+
+- Fix issue with field permissions check on add forms when the parent has no "Modify portal content" permission.
+  New: For add forms use the "Add portal content" permission as default field permission.
+  As great side effect vocabularies for i.e. AjaxSelectWidget from ``plone.app.content``,
+  which are using the check, are working on add forms in a context w/o "Modify portal content".
+  [jensens]
 
 
 2.4.1 (2017-03-26)

--- a/plone/app/dexterity/permissions.py
+++ b/plone/app/dexterity/permissions.py
@@ -109,6 +109,8 @@ class DXFieldPermissionChecker(object):
 class GenericFormFieldPermissionChecker(DXFieldPermissionChecker):
     """Permission checker for when we just have an add view"""
 
+    DEFAULT_PERMISSION = 'Add portal content'
+
     def __init__(self, view):
         if getattr(view, 'form_instance', None) is not None:
             view = view.form_instance


### PR DESCRIPTION
Fix issue with field permissions check on add forms when the parent (=container) has no "Modify portal content" permission.

New: For add forms use the "Add portal content" permission as default field permission. One can not have modify on a not-yet-created item.

As great side effect vocabularies for i.e. AjaxSelectWidget from ``plone.app.content``, which are using the check, are working on add forms in a context w/o "Modify portal content".