### PR TITLE
The ``ICategorization`` behavior should only expose those content lan…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ New features:
 
 Bug fixes:
 
+- The ``ICategorization`` behavior should only expose those content languages which are configured instead of all available languages.
+  [thet]
+
 - fix typo in deprecation message
   [tkimnguyen]
   

--- a/plone/app/dexterity/behaviors/metadata.py
+++ b/plone/app/dexterity/behaviors/metadata.py
@@ -117,7 +117,7 @@ class ICategorization(model.Schema):
 
     language = schema.Choice(
         title=_(u'label_language', default=u'Language'),
-        vocabulary='plone.app.vocabularies.AvailableContentLanguages',
+        vocabulary='plone.app.vocabularies.SupportedContentLanguages',
         required=False,
         missing_value='',
         defaultFactory=default_language,


### PR DESCRIPTION
…guages which are configured instead of all available languages.