### PR TITLE
[chg] Changed label id from 'label_contributors' to 'contributors' in…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Uniformity with the "Contributors" label.
+  [arsenico13] 
 
 
 2.4.5 (2017-08-27)
@@ -51,7 +52,7 @@ Bug fixes:
 
 - fix typo in deprecation message
   [tkimnguyen]
-  
+
 - Remove the transaction.begin call before creating a dx object,
   remove the transaction.commit call after creating a dx object.
   Fixes #243.

--- a/plone/app/dexterity/behaviors/metadata.py
+++ b/plone/app/dexterity/behaviors/metadata.py
@@ -208,7 +208,7 @@ class IOwnership(model.Schema):
     )
 
     contributors = schema.Tuple(
-        title=_(u'label_contributors', u'Contributors'),
+        title=_(u'contributors', u'Contributors'),
         description=_(
             u'help_contributors',
             default=u'The names of people that have contributed '


### PR DESCRIPTION
… metadata.py for more consistency


While working on a site localized in Italian, I noticed an "inconsistency" with the translation for the string "Contributors".
This will fix that.