### PR TITLE
Do not acquire constrain_types_mode from parent when not defined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not acquire ``constrain_types_mode`` from parent when not defined
+  [frapell]
 
 
 2.3.7 (2017-02-05)

--- a/plone/app/dexterity/behaviors/constrains.py
+++ b/plone/app/dexterity/behaviors/constrains.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.constrains import ISelectableConstrainTypes
+from Products.CMFPlone.utils import base_hasattr
 
 
 # constants for enableConstrain. Copied from AT
@@ -21,7 +22,7 @@ class ConstrainTypesBehavior(object):
         and can be adapted to ISelectableConstrainTypes.
         Else it is DISABLED
         """
-        if hasattr(self.context, 'constrain_types_mode'):
+        if base_hasattr(self.context, 'constrain_types_mode'):
             return self.context.constrain_types_mode
         parent = self.context.__parent__
         if not parent:

--- a/plone/app/dexterity/tests/test_constrains.py
+++ b/plone/app/dexterity/tests/test_constrains.py
@@ -81,6 +81,19 @@ class DocumentIntegrationTest(unittest.TestCase):
             constrains.DISABLED, behavior1.getConstrainTypesMode())
         self.assertEqual(constrains.ACQUIRE, behavior2.getConstrainTypesMode())
 
+    def test_constrainTypesAcquireDoesNotMatchParent(self):
+        """
+        The inner folder should return constrains.ACQUIRE and not the actual value of its parent
+        """
+        behavior1 = ISelectableConstrainTypes(self.folder)
+        behavior2 = ISelectableConstrainTypes(self.inner_folder)
+
+        behavior1.setConstrainTypesMode(constrains.DISABLED)
+        self.assertEqual(constrains.ACQUIRE, behavior2.getConstrainTypesMode())
+
+        behavior1.setConstrainTypesMode(constrains.ENABLED)
+        self.assertEqual(constrains.ACQUIRE, behavior2.getConstrainTypesMode())
+
     def test_constrainTypesModeValidSet(self):
         behavior = ISelectableConstrainTypes(self.folder)
         behavior.setConstrainTypesMode(constrains.ENABLED)


### PR DESCRIPTION
Use base_hasattr instead of plain hasattr so the constrain_types_mode would not be inherited from the parent if not defined