### PR TITLE
Don't break if types are without widgets or groups.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Don't break if types are without widgets or groups.
+  Fixes an error with displaying TTW Dexterity types via plone.app.contenttypes full_view. 
+  [thet]
 
 
 2.4.8 (2018-02-04)

--- a/plone/app/dexterity/browser/behaviors.pt
+++ b/plone/app/dexterity/browser/behaviors.pt
@@ -2,7 +2,7 @@
 <div class="portalMessage" tal:condition="view/status" tal:content="view/status"></div>
 
 <form action="." method="post" tal:attributes="action request/getURL; enctype view/enctype">
-<tal:widgets repeat="widget view/widgets/values">
+<tal:widgets repeat="widget view/widgets/values|nothing">
 
   <div class="field"
        tal:define="error widget/error;

--- a/plone/app/dexterity/browser/container.pt
+++ b/plone/app/dexterity/browser/container.pt
@@ -10,13 +10,13 @@
 <metal:main fill-slot="content-core">
 <metal:content-core define-macro="content-core">
 
-  <tal:block repeat="widget view/widgets/values">
+  <tal:block repeat="widget view/widgets/values|nothing">
       <tal:block tal:condition="python:widget.__name__ not in ('IBasic.title', 'IBasic.description', 'title', 'description',)">
           <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
       </tal:block>
   </tal:block>
 
-  <fieldset tal:repeat="group view/groups"
+  <fieldset tal:repeat="group view/groups|nothing"
             tal:attributes="id python:''.join((group.prefix, 'groups.', group.__name__)).replace('.', '-')">
       <legend tal:content="group/label" />
       <tal:block tal:repeat="widget group/widgets/values">
@@ -26,7 +26,7 @@
 
   <fieldset id="folder-listing">
       <legend i18n:translate="" i18n:domain="plone">Contents</legend>
-      <tal:block define="view nocall:context/folder_listing; listing_macro view/macros/listing">
+      <tal:block define="view nocall:context/folder_listing; listing_macro view/macros/listing|view/index/macros/listing">
           <metal:use_macro use-macro="listing_macro" />
       </tal:block>
   </fieldset>

--- a/plone/app/dexterity/browser/item.pt
+++ b/plone/app/dexterity/browser/item.pt
@@ -10,16 +10,16 @@
 <metal:main fill-slot="content-core">
 <metal:content-core define-macro="content-core">
 
-  <tal:block repeat="widget view/widgets/values">
+  <tal:block repeat="widget view/widgets/values|nothing">
     <tal:block tal:condition="python:widget.__name__ not in ('IBasic.title', 'IBasic.description', 'title', 'description',)">
       <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
     </tal:block>
   </tal:block>
 
-  <fieldset tal:repeat="group view/groups"
+  <fieldset tal:repeat="group view/groups|nothing"
             tal:attributes="id python:''.join((group.prefix, 'groups.', group.__name__)).replace('.', '-')">
     <legend tal:content="group/label" />
-    <tal:block tal:repeat="widget group/widgets/values">
+    <tal:block tal:repeat="widget group/widgets/values|nothing">
       <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
     </tal:block>
   </fieldset>


### PR DESCRIPTION
Fixes an error with displaying TTW Dexterity types via plone.app.contenttypes full_view.