### PR TITLE
Release upload lock when name chooser fails. [2.3.x]

### DIFF
--- a/news/276.bugfix
+++ b/news/276.bugfix
@@ -1,0 +1,1 @@
+Release upload lock when name chooser fails.  [maurits]

--- a/plone/app/dexterity/factories.py
+++ b/plone/app/dexterity/factories.py
@@ -35,9 +35,8 @@ class DXFileFactory(object):
         # otherwise I get ZPublisher.Conflict ConflictErrors
         # when uploading multiple files
         upload_lock.acquire()
-
-        newid = chooser.chooseName(name, self.context.aq_parent)
         try:
+            newid = chooser.chooseName(name, self.context.aq_parent)
             transaction.begin()
 
             # Try to determine which kind of NamedBlob we need


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.dexterity/issues/276