### PR TITLE
Do not acquire constrain_types_mode from parent when not defined.

### DIFF
--- a/news/284.bugfix
+++ b/news/284.bugfix
@@ -1,0 +1,2 @@
+Do not acquire ``constrain_types_mode`` from parent when not defined
+[frapell]

--- a/plone/app/dexterity/behaviors/constrains.py
+++ b/plone/app/dexterity/behaviors/constrains.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.constrains import ISelectableConstrainTypes
+from Products.CMFPlone.utils import base_hasattr
 
 
 # constants for enableConstrain. Copied from AT
@@ -21,7 +22,7 @@ class ConstrainTypesBehavior(object):
         and can be adapted to ISelectableConstrainTypes.
         Else it is DISABLED
         """
-        if hasattr(self.context, 'constrain_types_mode'):
+        if base_hasattr(self.context, 'constrain_types_mode'):
             return self.context.constrain_types_mode
         parent = self.context.__parent__
         if not parent:

--- a/plone/app/dexterity/tests/test_constrains.py
+++ b/plone/app/dexterity/tests/test_constrains.py
@@ -81,6 +81,19 @@ class DocumentIntegrationTest(unittest.TestCase):
             constrains.DISABLED, behavior1.getConstrainTypesMode())
         self.assertEqual(constrains.ACQUIRE, behavior2.getConstrainTypesMode())
 
+    def test_constrainTypesAcquireDoesNotMatchParent(self):
+        """
+        The inner folder should return constrains.ACQUIRE and not the actual value of its parent
+        """
+        behavior1 = ISelectableConstrainTypes(self.folder)
+        behavior2 = ISelectableConstrainTypes(self.inner_folder)
+
+        behavior1.setConstrainTypesMode(constrains.DISABLED)
+        self.assertEqual(constrains.ACQUIRE, behavior2.getConstrainTypesMode())
+
+        behavior1.setConstrainTypesMode(constrains.ENABLED)
+        self.assertEqual(constrains.ACQUIRE, behavior2.getConstrainTypesMode())
+
     def test_constrainTypesModeValidSet(self):
         behavior = ISelectableConstrainTypes(self.folder)
         behavior.setConstrainTypesMode(constrains.ENABLED)


### PR DESCRIPTION
This is the same fix as in https://github.com/plone/plone.app.dexterity/pull/264 but for master branch