### PR TITLE
reflect moves from plone.app.widgets to plone.app.z3cform

### DIFF
--- a/news/268.feature
+++ b/news/268.feature
@@ -1,0 +1,3 @@
+``IWidgetsLayer`` is no longer needed, use ``IPloneFormLayer`` instead.
+Import ``IFieldPermissionChecker`` from ``plone.app.z3cform`` instead of ``plone.app.widgets``.
+[jensens]

--- a/plone/app/dexterity/factories.py
+++ b/plone/app/dexterity/factories.py
@@ -11,8 +11,6 @@ from zope.component import adapter
 from zope.container.interfaces import INameChooser
 from zope.interface import implementer
 
-import transaction
-
 
 upload_lock = allocate_lock()
 

--- a/plone/app/dexterity/permissions.py
+++ b/plone/app/dexterity/permissions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
-from plone.app.widgets.interfaces import IFieldPermissionChecker
-from plone.app.widgets.interfaces import IWidgetsLayer
+from plone.app.z3cform.interfaces import IFieldPermissionChecker
+from plone.app.z3cform.interfaces import IPloneFormLayer
 from plone.autoform.interfaces import WIDGETS_KEY
 from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
 from plone.autoform.utils import resolveDottedName
@@ -21,7 +21,7 @@ from zope.security.interfaces import IPermission
 import six
 
 
-@implementer(IWidgetsLayer)
+@implementer(IPloneFormLayer)
 class MockRequest(TestRequest):
     pass
 

--- a/plone/app/dexterity/tests/test_permissions.py
+++ b/plone/app/dexterity/tests/test_permissions.py
@@ -4,7 +4,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from plone.app.widgets.interfaces import IWidgetsLayer
+from plone.app.z3cform.interfaces import IPloneFormLayer
 from plone.app.widgets.testing import PLONEAPPWIDGETS_DX_INTEGRATION_TESTING
 from plone.autoform.interfaces import WIDGETS_KEY
 from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
@@ -52,6 +52,7 @@ class IMockSchema(Interface):
     custom_widget_field = schema.TextLine()
     adapted_widget_field = schema.TextLine()
 
+
 IMockSchema.setTaggedValue(WRITE_PERMISSIONS_KEY, {
     'allowed_field': u'zope2.View',
     'disallowed_field': u'zope2.ViewManagementScreens',
@@ -66,14 +67,14 @@ IMockSchema.setTaggedValue(WIDGETS_KEY, {
 def _enable_custom_widget(field):
     provideAdapter(
         _custom_field_widget,
-        adapts=(getSpecification(field), IWidgetsLayer),
+        adapts=(getSpecification(field), IPloneFormLayer),
         provides=IFieldWidget
     )
 
 
 def _disable_custom_widget(field):
     base.unregisterAdapter(
-        required=(getSpecification(field), IWidgetsLayer, ),
+        required=(getSpecification(field), IPloneFormLayer, ),
         provided=IFieldWidget,
     )
 


### PR DESCRIPTION
Avoid deprecation warnings after cleanup over there:
- IWidgetsLayer->IPloneFormLayer
- import IFieldPermissionChecker from plone.app.z3cform