### PR TITLE
Default to a 4K x 4K browser window in Robot tests

### DIFF
--- a/news/292.bugfix
+++ b/news/292.bugfix
@@ -1,0 +1,3 @@
+- Use the shared 'Plone test setup' and 'Plone test teardown' keywords in Robot
+  tests.
+  [Rotonen]

--- a/plone/app/dexterity/tests/robot/test_types.robot
+++ b/plone/app/dexterity/tests/robot/test_types.robot
@@ -1,11 +1,13 @@
 *** Settings *****************************************************************
 
 Resource  plone/app/robotframework/keywords.robot
+Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Run keywords  Open test browser
-Test Teardown  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 
 *** Test cases ***************************************************************


### PR DESCRIPTION
I'm in the process of trying to unify Robot test setups and teardowns. This is a part of that effort.

In tandem with https://github.com/plone/plone.app.robotframework/pull/110
Closes https://github.com/plone/plone.app.dexterity/issues/292