### PR TITLE
Do not require nextPreviousEnabled.

### DIFF
--- a/news/312.bugfix
+++ b/news/312.bugfix
@@ -1,0 +1,1 @@
+Do not require nextPreviousEnabled

--- a/plone/app/dexterity/behaviors/nextprevious.py
+++ b/plone/app/dexterity/behaviors/nextprevious.py
@@ -43,7 +43,8 @@ class INextPreviousToggle(model.Schema):
             default=u'This enables next/previous widget on content items ' +
                     u'contained in this folder.'
         ),
-        default=False
+        default=False,
+        required=False,
     )
 
     directives.omitted('nextPreviousEnabled')


### PR DESCRIPTION
It would break with https://github.com/plone/plone.app.z3cform/pull/114/commits/7c0688e