### PR TITLE
Fix schema tests by waiting longer so the schema is invalidated.

### DIFF
--- a/news/313.bugfix
+++ b/news/313.bugfix
@@ -1,3 +1,3 @@
 Update tests to fix updated schema cache.
 See https://github.com/plone/plone.dexterity/pull/137
-[@avoinea]
+[@avoinea, maurits]

--- a/plone/app/dexterity/tests/editing.rst
+++ b/plone/app/dexterity/tests/editing.rst
@@ -116,11 +116,16 @@ and saved::
   >>> from plone.i18n.normalizer.interfaces import IIDNormalizer
   >>> from plone.schemaeditor import interfaces
   >>> normalizer = component.getUtility(IIDNormalizer)
+  >>> import time
   >>> for name, factory in sorted(component.getUtilitiesFor(
   ...     interfaces.IFieldFactory)):
   ...     if hasattr(factory, 'protected') and factory.protected(None):
   ...         continue
   ...     browser.open(schemaeditor_url)
+  ...     # If two changes happen in the same second, the schema lookup will find an old schema,
+  ...     # so we sleep till the next second.
+  ...     now = time.time()
+  ...     time.sleep(int(now) + 1 - now)
   ...     browser.getLink('Add new field').click()
   ...     browser.getControl('Title').value = name
   ...     field_id = normalizer.normalize(name).replace('-', '_')


### PR DESCRIPTION
When a schema is changed twice within the same second, the newest changes do not make it to the schema cache.
So we wait till the next second.
See comments here: https://github.com/plone/plone.app.dexterity/issues/313