### PR TITLE
Fix warning about legacy version specifiers in setup.py.

### DIFF
--- a/news/337.bugfix
+++ b/news/337.bugfix
@@ -1,0 +1,2 @@
+Fix warning about legacy version specifiers in setup.py.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,10 @@ setup(
     install_requires=[
         # Dexterity
         'plone.app.textfield',
-        'plone.behavior>=1.0b5',
-        'plone.dexterity >= 2.2.2dev',
+        'plone.behavior>=1.0',
+        'plone.dexterity>=2.2.2',
         'plone.formwidget.namedfile',
-        'plone.namedfile[scales] >=1.0b5dev-r36016',
+        'plone.namedfile[scales]>=1.0.0',
         'plone.rfc822',
         'plone.schemaeditor >1.3.3',
         # Plone/Zope core
@@ -60,11 +60,11 @@ setup(
         'plone.app.layout',
         'plone.app.uuid',
         'plone.app.z3cform>=1.1.0',
-        'plone.autoform >=1.1dev',
+        'plone.autoform>=1.1',
         'plone.contentrules',
         'plone.portlets',
         'plone.schema>=1.1.0',
-        'plone.supermodel>=1.1dev',
+        'plone.supermodel>=1.1',
         'plone.z3cform>=0.6.0',
         'Products.CMFCore',
         'Products.GenericSetup',
@@ -77,7 +77,7 @@ setup(
         'zope.deprecation',
         'zope.schema',
         'zope.publisher',
-        'z3c.form>=3.0.0a1',
+        'z3c.form>=3.0.0',
     ],
     extras_require={
         'test': [
@@ -87,7 +87,7 @@ setup(
         'grok': [
             'five.grok',
             'plone.directives.dexterity',
-            'plone.directives.form >=1.1dev',
+            'plone.directives.form>=1.1',
         ],
         'relations': [
             'plone.app.relationfield',


### PR DESCRIPTION
Warning on startup:

```
pkg_resources/_vendor/packaging/specifiers.py:273: DeprecationWarning:
Creating a LegacyVersion has been deprecated and will be removed in the next major release
```

It fell over `plone.namedfile[scales] >=1.0b5dev-r36016`.
I simply removed all the dev/alpha/beta markers from all requirements.