### PR TITLE
Depend on `plone.namedfile` core instead of its empty `[scales]` extra.

### DIFF
--- a/news/106.bugfix
+++ b/news/106.bugfix
@@ -1,0 +1,2 @@
+Depend on `plone.namedfile` core instead of its empty `[scales]` extra.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'plone.behavior>=1.0',
         'plone.dexterity>=2.2.2',
         'plone.formwidget.namedfile',
-        'plone.namedfile[scales]>=1.0.0',
+        'plone.namedfile>=1.0.0',
         'plone.rfc822',
         'plone.schemaeditor >1.3.3',
         # Plone/Zope core


### PR DESCRIPTION
See https://github.com/plone/plone.namedfile/issues/106