### PR TITLE
Modeleditor: when there is no model_source yet, show the model_file.

### DIFF
--- a/news/3473.bugfix
+++ b/news/3473.bugfix
@@ -1,0 +1,2 @@
+Modeleditor: when there is no model_source yet, show the model_file.
+[maurits]

--- a/plone/app/dexterity/browser/modeleditor.py
+++ b/plone/app/dexterity/browser/modeleditor.py
@@ -2,6 +2,7 @@
 from AccessControl import Unauthorized
 from lxml import etree
 from plone.app.dexterity import _
+from plone.supermodel import serializeModel
 from plone.supermodel.parser import SupermodelParseError
 from Products.CMFPlone.utils import safe_bytes
 from Products.CMFPlone.utils import safe_unicode
@@ -27,7 +28,13 @@ class ModelEditorView(BrowserView):
     @property
     def model_source(self):
         # Return modified source from textarea or the original FTI source.
-        return self.request.form.get("source") or self.context.fti.model_source
+        source = self.request.form.get("source") or self.context.fti.model_source
+        if source:
+            return source
+
+        # or serialize the model file
+        model = self.context.fti.lookupModel()
+        return serializeModel(model)
 
     def authorized(self, context, request):
         authenticator = queryMultiAdapter((context, request), name=u"authenticator")


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/3473