### PR TITLE
Modeleditor: Don't double escape the xml.

### DIFF
--- a/news/358.bugfix
+++ b/news/358.bugfix
@@ -1,0 +1,7 @@
+Modeleditor: Don't double escape the xml.
+
+Use the page template's structure keyword when inserting the escaped HTML into
+the modeleditor's textarea. This allows the source code pattern to properly
+parse and display the XML for editing.
+
+Fixes: #357

--- a/plone/app/dexterity/browser/modeleditor.pt
+++ b/plone/app/dexterity/browser/modeleditor.pt
@@ -44,8 +44,8 @@
 
       <textarea
           name="source"
-          class="modeleditor__source pat-code-editor"
-          data-pat-code-editor="language: xml; theme: okaidia">${view/escaped_model_source}</textarea>
+          class="modeleditor__source pat-code-editor language-xml"
+          tal:content="structure view/escaped_model_source"></textarea>
 
       <br />
       

--- a/plone/app/dexterity/tests/editing.rst
+++ b/plone/app/dexterity/tests/editing.rst
@@ -173,15 +173,12 @@ Go there and find the XML model source in a textarea, ready to be edited
   >>> '<textarea name="source"' in browser.contents
   True
 
-  >>> '&amp;lt;schema&amp;gt;' in browser.contents
+  >>> '&lt;schema&gt;' in browser.contents
   True
 
   >>> model_source = portal.portal_types.plonista.model_source
   >>> escaped_model_source = escape(model_source, quote=False)
   >>> escaped_model_source in browser.contents
-  False
-  >>> again_escaped_model_source = escape(escaped_model_source, quote=False)
-  >>> again_escaped_model_source in browser.contents
   True
 
 There should be an authenticator in the `save` form::


### PR DESCRIPTION
Use the page template's structure keyword when inserting the escaped HTML into the modeleditor's textarea. This allows the source code pattern to properly parse and display the XML for editing.

Fixes: #357

Together:
https://github.com/plone/plone.staticresources/pull/259
https://github.com/plone/plone.app.dexterity/pull/358