### PR TITLE
Modeleditor simplify

### DIFF
--- a/news/359.bugfix.1
+++ b/news/359.bugfix.1
@@ -1,0 +1,2 @@
+Use the tal engine to escape HTML via non-structure variable insertion.
+[thet]

--- a/news/359.bugfix.2
+++ b/news/359.bugfix.2
@@ -1,0 +1,3 @@
+Deprecate ModelEditorView.escaped_model_source which is not needed anymore.
+It will be removed in Plone 7.
+[thet]

--- a/news/359.bugfix.3
+++ b/news/359.bugfix.3
@@ -1,0 +1,3 @@
+Restore and deprecate "ModelEditorView.modelSource".
+It will be removed in Plone 7.
+[thet]

--- a/plone/app/dexterity/browser/modeleditor.pt
+++ b/plone/app/dexterity/browser/modeleditor.pt
@@ -45,7 +45,7 @@
       <textarea
           name="source"
           class="modeleditor__source pat-code-editor language-xml"
-          tal:content="structure view/escaped_model_source"></textarea>
+          tal:content="view/model_source"></textarea>
 
       <br />
       

--- a/plone/app/dexterity/browser/modeleditor.py
+++ b/plone/app/dexterity/browser/modeleditor.py
@@ -9,6 +9,7 @@ from plone.supermodel.parser import SupermodelParseError
 from Products.Five import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import queryMultiAdapter
+from zope.deprecation import deprecate
 
 import html
 
@@ -20,6 +21,11 @@ class ModelEditorView(BrowserView):
     """Editor view."""
 
     @property
+    @deprecate(
+        """`ModelEditorView.escaped_model_source` is deprecated will be removed
+in Plone 7. Use `model_source` without the `structure` TALES expression
+instead."""
+    )
     def escaped_model_source(self):
         # Return the HTML escaped model source.
         return html.escape(self.model_source, False)
@@ -74,7 +80,6 @@ class ModelEditorView(BrowserView):
         save = "form.button.save" in self.request.form
         source = self._unescaped_source_from_request()
         if save and source:
-
             # First, check for authenticator
             if not self.authorized(self.context, self.request):
                 raise Unauthorized

--- a/plone/app/dexterity/browser/modeleditor.py
+++ b/plone/app/dexterity/browser/modeleditor.py
@@ -30,6 +30,15 @@ instead."""
         # Return the HTML escaped model source.
         return html.escape(self.model_source, False)
 
+    @deprecate(
+        """`ModelEditorView.modelSource` is deprecated and will be removed in
+Plone 7. Use `model_source` instead.
+"""
+    )
+    def modelSource(self):
+        # BBB
+        return self.model_source
+
     @property
     def model_source(self):
         # Return modified source from textarea or the original FTI source.


### PR DESCRIPTION
- Use the tal engine to escape HTML via non-structure variable insertion.
- Restore BBB method.