### PR TITLE
Config with default template 5d669ee9

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,8 @@
 root = true
 
 
-[*]  # For All Files
+[*]
+# Default settings for all files.
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true
@@ -33,7 +34,8 @@ indent_size = 4
 # 2 space indentation
 indent_size = 2
 
-[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]  # Frontend development
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]
+# Frontend development
 # 2 space indentation
 indent_size = 2
 max_line_length = 80

--- a/.meta.toml
+++ b/.meta.toml
@@ -14,3 +14,6 @@ extra_lines = """
 per-file-ignores =
     plone/app/dexterity/textindexer/__init__.py:F401
 """
+
+[tox]
+constraints_file = "https://dist.plone.org/release/6.1-dev/constraints.txt"

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "6e36bcc4"
+commit-id = "5d669ee9"
 
 [pyproject]
 codespell_ignores = "hove"

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,11 @@
+# Generated from:
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,19 +134,26 @@ ignore-packages = ['plone.app.content', 'plone.app.relationfield', 'plone.direct
 [tool.check-manifest]
 ignore = [
     ".editorconfig",
+    ".flake8",
     ".meta.toml",
     ".pre-commit-config.yaml",
-    "tox.ini",
-    ".flake8",
+    "dependabot.yml",
     "mx.ini",
+    "tox.ini",
 
 ]
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pyproject]
 #  check_manifest_ignores = """
 #      "*.map.js",
 #      "*.pyc",
+#  """
+#  check_manifest_extra_lines = """
+#  ignore-bad-ideas = [
+#      "some/test/file/PKG-INFO",
+#  ]
 #  """
 ##
 

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ set_env =
 ##
 deps =
     zope.testrunner
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 ##
 # Specify additional deps in .meta.toml:
@@ -152,7 +152,7 @@ set_env =
 deps =
     coverage
     zope.testrunner
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     rfbrowser init
@@ -171,7 +171,7 @@ deps =
     twine
     build
     towncrier
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     # fake version to not have to install the package
@@ -202,7 +202,7 @@ allowlist_externals =
 deps =
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     # Generate the full dependency tree

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ set_env =
 ##
 deps =
     zope.testrunner
-    -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
 ##
 # Specify additional deps in .meta.toml:
@@ -152,13 +152,14 @@ set_env =
 deps =
     coverage
     zope.testrunner
-    -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
 commands =
     rfbrowser init
     coverage run --branch --source plone.app.dexterity {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir} -s plone.app.dexterity {posargs}
     coverage report -m --format markdown
     coverage xml
+    coverage html
 extras =
     test
 
@@ -170,7 +171,7 @@ deps =
     twine
     build
     towncrier
-    -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
 commands =
     # fake version to not have to install the package
@@ -184,6 +185,9 @@ commands =
 description = ensure there are no cyclic dependencies
 use_develop = true
 skip_install = false
+# Here we must always constrain the package deps to what is already installed,
+# otherwise we simply get the latest from PyPI, which may not work.
+constrain_package_deps = true
 set_env =
 
 ##
@@ -198,7 +202,7 @@ allowlist_externals =
 deps =
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
 commands =
     # Generate the full dependency tree


### PR DESCRIPTION
Mostly this PR demonstrates that currently we need to manually make some adjustments to `tox.ini` if we have a package that we need to test on Plone 6.1.  That seems the only file that needs changes, which is good.
See https://github.com/plone/meta/issues/210
