### PR TITLE
Re-enable subjects into SearchableText indexing

### DIFF
--- a/news/407.bugfix
+++ b/news/407.bugfix
@@ -1,0 +1,1 @@
+- Re-enable subjects into SearchableText indexing [cekk]

--- a/plone/app/dexterity/textindexer/__init__.py
+++ b/plone/app/dexterity/textindexer/__init__.py
@@ -1,6 +1,7 @@
 """Dynamic SearchableText index for dexterity content types"""
 
 from plone.app.dexterity.behaviors.metadata import IBasic
+from plone.app.dexterity.behaviors.metadata import ICategorization
 from plone.app.dexterity.textindexer import utils
 from plone.app.dexterity.textindexer.directives import searchable
 from plone.app.dexterity.textindexer.directives import SEARCHABLE_KEY
@@ -10,3 +11,4 @@ from plone.app.dexterity.textindexer.interfaces import IDynamicTextIndexExtender
 
 utils.searchable(IBasic, "title")
 utils.searchable(IBasic, "description")
+utils.searchable(ICategorization, "subjects")

--- a/plone/app/dexterity/textindexer/tests/test_basic_behavior.py
+++ b/plone/app/dexterity/textindexer/tests/test_basic_behavior.py
@@ -1,4 +1,5 @@
 from plone.app.dexterity.behaviors.metadata import IBasic
+from plone.app.dexterity.behaviors.metadata import ICategorization
 from plone.app.dexterity.textindexer.tests.helpers import get_searchable_fields
 from unittest import TestCase
 
@@ -9,3 +10,6 @@ class TestBasicBehaviorIsSearchable(TestCase):
 
     def test_description_is_searchable(self):
         self.assertIn("description", get_searchable_fields(IBasic))
+
+    def test_subjects_is_searchable(self):
+        self.assertIn("subjects", get_searchable_fields(ICategorization))


### PR DESCRIPTION
It was missing from new texindexer configuration