### PR TITLE
Experimental: proactive Dexterity schema/behavior cache warmer at startup

### DIFF
--- a/news/+dexterity-cache-warmer.feature
+++ b/news/+dexterity-cache-warmer.feature
@@ -1,0 +1,1 @@
+Add an optional startup cache warmer (``plone.app.dexterity.warmup``) that proactively builds every Dexterity type's schema and behavior schemata at process start, removing the cold first-render penalty.  Opt out via the ``DEXTERITY_WARMER_ENABLED`` environment variable; time-bounded by ``DEXTERITY_WARMER_BUDGET_SECONDS`` (default 30).  [jensens]

--- a/src/plone/app/dexterity/configure.zcml
+++ b/src/plone/app/dexterity/configure.zcml
@@ -20,6 +20,12 @@
   <include package="plone.dexterity" />
   <include package="plone.behavior" />
 
+  <!-- Proactively warm Dexterity schema/behavior caches at process startup. -->
+  <subscriber
+      for="zope.processlifetime.IDatabaseOpenedWithRoot"
+      handler=".warmup.warm_on_startup"
+      />
+
   <genericsetup:registerProfile
       name="default"
       title="Dexterity Content Types"

--- a/src/plone/app/dexterity/tests/test_warmup.py
+++ b/src/plone/app/dexterity/tests/test_warmup.py
@@ -1,11 +1,11 @@
-import unittest
-
-from zope.interface import Interface
-from zope import schema as zs
-
-from plone.app.testing import setRoles, TEST_USER_ID
 from plone.app.dexterity.testing import DEXTERITY_INTEGRATION_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from plone.dexterity.fti import DexterityFTI
+from zope import schema as zs
+from zope.interface import Interface
+
+import unittest
 
 
 class IWarmTestSchema(Interface):
@@ -112,8 +112,10 @@ class WarmSubscriberTest(unittest.TestCase):
         return _Event()
 
     def test_subscriber_disabled_is_noop(self):
+        from plone.app.dexterity.warmup import DEXTERITY_WARMER_ENABLED
+        from plone.app.dexterity.warmup import warm_on_startup
+
         import os
-        from plone.app.dexterity.warmup import warm_on_startup, DEXTERITY_WARMER_ENABLED
 
         os.environ[DEXTERITY_WARMER_ENABLED] = "false"
         try:

--- a/src/plone/app/dexterity/tests/test_warmup.py
+++ b/src/plone/app/dexterity/tests/test_warmup.py
@@ -45,3 +45,51 @@ class WarmSiteTest(unittest.TestCase):
         self.assertIs(SCHEMA_CACHE.get("warmtype"), IWarmTestSchema)
         # behavior schemata were yielded too (>1 schema for the type)
         self.assertGreaterEqual(report.schemata, 2)
+
+
+class WarmErrorIsolationTest(unittest.TestCase):
+    layer = DEXTERITY_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_one_failing_type_does_not_stop_the_rest(self):
+        from plone.app.dexterity import warmup
+
+        _add_dexterity_type(self.portal, "goodtype")
+        _add_dexterity_type(self.portal, "badtype")
+
+        real = warmup.iterSchemataForType
+
+        def fake(portal_type):
+            if portal_type == "badtype":
+                raise RuntimeError("boom")
+            return real(portal_type)
+
+        warmup.iterSchemataForType = fake
+        try:
+            report = warmup.warm_site(self.portal)
+        finally:
+            warmup.iterSchemataForType = real
+
+        self.assertIn("goodtype", report.warmed_types)
+        self.assertNotIn("badtype", report.warmed_types)
+        self.assertEqual(len(report.errors), 1)
+        self.assertEqual(report.errors[0][0], "badtype")
+
+
+class WarmAllTest(unittest.TestCase):
+    layer = DEXTERITY_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.app = self.layer["app"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_warm_all_finds_the_plone_site(self):
+        from plone.app.dexterity.warmup import warm_all
+
+        _add_dexterity_type(self.portal, "warmtype2")
+        report = warm_all(self.app)
+        self.assertIn("warmtype2", report.warmed_types)

--- a/src/plone/app/dexterity/tests/test_warmup.py
+++ b/src/plone/app/dexterity/tests/test_warmup.py
@@ -93,3 +93,38 @@ class WarmAllTest(unittest.TestCase):
         _add_dexterity_type(self.portal, "warmtype2")
         report = warm_all(self.app)
         self.assertIn("warmtype2", report.warmed_types)
+
+
+class WarmSubscriberTest(unittest.TestCase):
+    layer = DEXTERITY_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def _make_event(self):
+        # minimal IDatabaseOpenedWithRoot-shaped event with the test ZODB
+        db = self.portal._p_jar.db()
+
+        class _Event:
+            database = db
+
+        return _Event()
+
+    def test_subscriber_disabled_is_noop(self):
+        import os
+        from plone.app.dexterity.warmup import warm_on_startup, DEXTERITY_WARMER_ENABLED
+
+        os.environ[DEXTERITY_WARMER_ENABLED] = "false"
+        try:
+            # disabled: must be a no-op and must not raise
+            warm_on_startup(self._make_event())
+        finally:
+            del os.environ[DEXTERITY_WARMER_ENABLED]
+
+    def test_subscriber_enabled_runs_without_error(self):
+        from plone.app.dexterity.warmup import warm_on_startup
+
+        # default-enabled: opens a fresh connection, warms the layer's committed
+        # Plone site, and must not raise.
+        warm_on_startup(self._make_event())

--- a/src/plone/app/dexterity/tests/test_warmup.py
+++ b/src/plone/app/dexterity/tests/test_warmup.py
@@ -1,0 +1,47 @@
+import unittest
+
+from zope.interface import Interface
+from zope import schema as zs
+
+from plone.app.testing import setRoles, TEST_USER_ID
+from plone.app.dexterity.testing import DEXTERITY_INTEGRATION_TESTING
+from plone.dexterity.fti import DexterityFTI
+
+
+class IWarmTestSchema(Interface):
+    foo = zs.TextLine(title="foo", required=False)
+
+
+def _add_dexterity_type(portal, type_id, behaviors=()):
+    fti = DexterityFTI(type_id)
+    fti.klass = "plone.dexterity.content.Item"
+    fti.schema = "plone.app.dexterity.tests.test_warmup.IWarmTestSchema"
+    fti.behaviors = tuple(behaviors)
+    portal.portal_types._setObject(type_id, fti)
+    return fti
+
+
+class WarmSiteTest(unittest.TestCase):
+    layer = DEXTERITY_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_warm_site_warms_type_and_behavior(self):
+        from plone.app.dexterity.warmup import warm_site
+        from plone.dexterity.schema import SCHEMA_CACHE
+
+        _add_dexterity_type(
+            self.portal,
+            "warmtype",
+            behaviors=("plone.app.dexterity.behaviors.metadata.IBasic",),
+        )
+        report = warm_site(self.portal)
+        # our type counted, no errors
+        self.assertIn("warmtype", report.warmed_types)
+        self.assertEqual(report.errors, [])
+        # main schema is now cached (and is our test schema)
+        self.assertIs(SCHEMA_CACHE.get("warmtype"), IWarmTestSchema)
+        # behavior schemata were yielded too (>1 schema for the type)
+        self.assertGreaterEqual(report.schemata, 2)

--- a/src/plone/app/dexterity/warmup.py
+++ b/src/plone/app/dexterity/warmup.py
@@ -70,3 +70,23 @@ def warm_site(site, deadline=None):
             report.errors.append((portal_type, repr(exc)))
     report.duration = time.monotonic() - start
     return report
+
+
+def warm_all(app, budget_seconds=DEFAULT_BUDGET):
+    """Warm every Plone site found directly under the Zope app root.
+
+    ``setSite`` is set around each site so CA/utility lookups resolve, and restored
+    afterwards. A single ``budget_seconds`` deadline is shared across all sites.
+    """
+    report = WarmReport()
+    deadline = time.monotonic() + budget_seconds if budget_seconds else None
+    previous_site = getSite()
+    try:
+        for obj in app.objectValues():
+            if not IPloneSiteRoot.providedBy(obj):
+                continue
+            setSite(obj)
+            report.merge(warm_site(obj, deadline=deadline))
+    finally:
+        setSite(previous_site)
+    return report

--- a/src/plone/app/dexterity/warmup.py
+++ b/src/plone/app/dexterity/warmup.py
@@ -1,0 +1,72 @@
+"""Proactive warmer for the process-global Dexterity schema/behavior caches.
+
+Building a Dexterity type's schema (and its behavior schemata) is lazy and, on a
+cold process, expensive (zope.interface construction + resolution order). This
+module builds them up front via the canonical ``iterSchemataForType`` API, so the
+first real render does not pay that cost.
+
+See the design doc: 2026-06-15-dexterity-cache-warmer-design.
+"""
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+
+from zope.component import adapter
+from zope.component.hooks import getSite, setSite
+from zope.processlifetime import IDatabaseOpenedWithRoot
+
+from Products.CMFCore.utils import getToolByName
+from plone.base.interfaces import IPloneSiteRoot
+from plone.dexterity.interfaces import IDexterityFTI
+from plone.dexterity.utils import iterSchemataForType
+
+log = logging.getLogger("plone.app.dexterity.warmup")
+
+ENABLED_ENV = "DEXTERITY_WARMER_ENABLED"
+BUDGET_ENV = "DEXTERITY_WARMER_BUDGET_SECONDS"
+DEFAULT_BUDGET = 30.0
+
+
+@dataclass
+class WarmReport:
+    """Result of a warm pass."""
+
+    warmed_types: list = field(default_factory=list)  # portal_type ids warmed OK
+    schemata: int = 0  # total schemata built (main + behaviors)
+    errors: list = field(default_factory=list)  # list of (portal_type, repr(exc))
+    duration: float = 0.0  # seconds
+
+    def merge(self, other):
+        self.warmed_types.extend(other.warmed_types)
+        self.schemata += other.schemata
+        self.errors.extend(other.errors)
+        self.duration += other.duration
+
+
+def warm_site(site, deadline=None):
+    """Build the schema + behavior schemata for every Dexterity FTI of ``site``.
+
+    Isolated per FTI: a failure is recorded and warming continues. ``deadline`` is
+    an optional ``time.monotonic()`` value after which the pass stops early.
+    """
+    report = WarmReport()
+    start = time.monotonic()
+    types_tool = getToolByName(site, "portal_types")
+    for fti in types_tool.objectValues():
+        if not IDexterityFTI.providedBy(fti):
+            continue
+        if deadline is not None and time.monotonic() > deadline:
+            log.warning("warmup: time budget exceeded, stopping early")
+            break
+        portal_type = fti.getId()
+        try:
+            schemata = list(iterSchemataForType(portal_type))
+            report.warmed_types.append(portal_type)
+            report.schemata += len(schemata)
+        except Exception as exc:  # noqa: BLE001 - best-effort, never propagate
+            log.exception("warmup failed for type %s", portal_type)
+            report.errors.append((portal_type, repr(exc)))
+    report.duration = time.monotonic() - start
+    return report

--- a/src/plone/app/dexterity/warmup.py
+++ b/src/plone/app/dexterity/warmup.py
@@ -8,19 +8,20 @@ first real render does not pay that cost.
 See the design doc: 2026-06-15-dexterity-cache-warmer-design.
 """
 
-import logging
-import os
-import time
-from dataclasses import dataclass, field
-
-from zope.component import adapter
-from zope.component.hooks import getSite, setSite
-from zope.processlifetime import IDatabaseOpenedWithRoot
-
-from Products.CMFCore.utils import getToolByName
+from dataclasses import dataclass
+from dataclasses import field
 from plone.base.interfaces import IPloneSiteRoot
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.utils import iterSchemataForType
+from Products.CMFCore.utils import getToolByName
+from zope.component import adapter
+from zope.component.hooks import getSite
+from zope.component.hooks import setSite
+from zope.processlifetime import IDatabaseOpenedWithRoot
+
+import logging
+import os
+import time
 
 log = logging.getLogger("plone.app.dexterity.warmup")
 

--- a/src/plone/app/dexterity/warmup.py
+++ b/src/plone/app/dexterity/warmup.py
@@ -24,8 +24,8 @@ from plone.dexterity.utils import iterSchemataForType
 
 log = logging.getLogger("plone.app.dexterity.warmup")
 
-ENABLED_ENV = "DEXTERITY_WARMER_ENABLED"
-BUDGET_ENV = "DEXTERITY_WARMER_BUDGET_SECONDS"
+DEXTERITY_WARMER_ENABLED = "DEXTERITY_WARMER_ENABLED"
+DEXTERITY_WARMER_BUDGET_SECONDS = "DEXTERITY_WARMER_BUDGET_SECONDS"
 DEFAULT_BUDGET = 30.0
 
 
@@ -90,3 +90,49 @@ def warm_all(app, budget_seconds=DEFAULT_BUDGET):
     finally:
         setSite(previous_site)
     return report
+
+
+def _enabled():
+    return os.environ.get(DEXTERITY_WARMER_ENABLED, "true").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _budget():
+    try:
+        return float(os.environ.get(DEXTERITY_WARMER_BUDGET_SECONDS, DEFAULT_BUDGET))
+    except (TypeError, ValueError):
+        return DEFAULT_BUDGET
+
+
+@adapter(IDatabaseOpenedWithRoot)
+def warm_on_startup(event):
+    """Synchronously warm all Plone sites at process startup.
+
+    Best-effort: any failure is logged and swallowed so process startup always
+    proceeds. Runs before the WSGI server starts serving, so a container's
+    readiness probe only passes once warming is done.
+    """
+    if not _enabled():
+        log.info("Dexterity cache warmer disabled via %s", DEXTERITY_WARMER_ENABLED)
+        return
+    connection = event.database.open()
+    try:
+        app = connection.root()["Application"]
+        report = warm_all(app, budget_seconds=_budget())
+        log.info(
+            "Dexterity cache warmer: %d types, %d schemata, %d errors in %.2fs",
+            len(report.warmed_types),
+            report.schemata,
+            len(report.errors),
+            report.duration,
+        )
+        if report.errors:
+            log.warning("Dexterity cache warmer errors: %r", report.errors)
+    except Exception:  # noqa: BLE001 - never block startup
+        log.exception("Dexterity cache warmer failed; continuing startup")
+    finally:
+        connection.close()


### PR DESCRIPTION
**Experimental — opening as draft for visibility and discussion.**

## Why

Profiling a production Plone 6.2 site (zodb-pgjsonb storage) showed cold page renders of
**5–8 s** vs **~0.4 s** warm (and ~0.12 s on a Varnish HIT). A py-spy sample (1719 frames)
attributed the cold cost overwhelmingly to the **Dexterity schema / Zope Component Architecture**
machinery (~25 %+: `dexterity/schema.py`, `dexterity/content.py` descriptors, `interface/ro.py`
resolution order, behavior lookups) — **not** storage/DB (~5 % PG round-trip wait) or blobs (~0 %).
The expensive part (generated schema interfaces + their resolution order + global `IBehavior`
lookups) is built lazily, once per process, on the first request that touches each type.

## What

A startup subscriber (`IDatabaseOpenedWithRoot`) that, before the server starts serving, walks
every Dexterity FTI of every Plone site and exhausts
`plone.dexterity.utils.iterSchemataForType(portal_type)`. This builds the (process-global)
schema interfaces, resolution orders and behavior schema lookups up front — no rendering, no HTTP,
no content instances. New module `plone/app/dexterity/warmup.py` + a `<subscriber>` in
`configure.zcml` + `tests/test_warmup.py`. Best-effort and isolated: a broken FTI is logged and
skipped, any failure is swallowed so startup always proceeds. Gated by env vars
`DEXTERITY_WARMER_ENABLED` (default on) and `DEXTERITY_WARMER_BUDGET_SECONDS` (default 30).

## Caveats / open questions for reviewers

- The per-type `SCHEMA_CACHE` memos are stored as `_v_` attributes **on the FTI** (so per ZODB
  connection / per worker thread, `_p_mtime`-keyed — deliberately, for correct cross-connection/
  cross-pod invalidation). A single-connection startup pass therefore warms the **expensive
  process-global** layer (interface construction + RO + global `IBehavior` lookups); the cheaper
  per-connection memo still refills per thread on first traffic. Field data on whether that
  residual matters to follow in this PR.
- Default-on here for evaluation; happy to make it default-off for a first release.
- The pure `warm_site`/`warm_all` logic could arguably live in `plone.dexterity`; it is placed in
  `plone.app.dexterity` because the site scan needs `IPloneSiteRoot` (CMFPlone).

## Status

Branch passes the full `plone.app.dexterity` suite (108 tests). Cold-vs-warm field measurements
on a representative site will be added to this PR before un-drafting.

---
*Developed with AI assistance (Claude / Claude Code), reviewed by a human.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)